### PR TITLE
Tprime evaluation and Solve TICA problem with not-symmetric Correlation Matrix

### DIFF
--- a/mlcvs/models/linear.py
+++ b/mlcvs/models/linear.py
@@ -208,7 +208,10 @@ class LinearCV(torch.nn.Module):
             out += " FUNC="
             for j in range(self.n_features):
                 w = weights[j, i]
-                s = "+" if w > 0 else ""
+                if j==0:
+                    s = ""
+                else:
+                    s = "+" if w > 0 else ""
                 if self.normIn:
                     m = mean[j]
                     s2 = "+" if m < 0 else "-"

--- a/mlcvs/models/nn.py
+++ b/mlcvs/models/nn.py
@@ -129,7 +129,7 @@ class NeuralNetworkCV(torch.nn.Module):
         # Optimizer
         self.opt_ = None
         self.earlystopping_ = None
-        self.LRScheduler_ = None
+        self.lrscheduler_ = None
 
         # Generic attributes
         self.name_ = "NN_CV"
@@ -291,7 +291,7 @@ class NeuralNetworkCV(torch.nn.Module):
         log: bool, optional
             print verbose info
         """
-        self.LRScheduler_ = LRScheduler(optimizer, patience=patience, min_lr=min_lr, factor=factor, log=log
+        self.lrscheduler_ = LRScheduler(optimizer, patience=patience, min_lr=min_lr, factor=factor, log=log
         )
 
     # Input / output standardization

--- a/mlcvs/models/nn.py
+++ b/mlcvs/models/nn.py
@@ -52,7 +52,7 @@ class NeuralNetworkCV(torch.nn.Module):
     """
 
     def __init__(
-        self, layers, activation="relu", **kwargs 
+        self, layers, activation="relu", random_initialization=False, **kwargs 
 
     ):
         """
@@ -64,7 +64,8 @@ class NeuralNetworkCV(torch.nn.Module):
             Number of neurons per layer
         activation : string
             Activation function (relu, tanh, elu, linear)
-        devi
+        random_initialization: bool
+            if initialize the weights of the network with random values uniform distributed in (0,1]
 
         """
         super().__init__(**kwargs)
@@ -100,7 +101,11 @@ class NeuralNetworkCV(torch.nn.Module):
         self.n_hidden = layers[-1]
 
         # Linear projection output
-        weight = torch.eye(self.n_hidden)
+        # Initialization of the weights and offsets
+        if random_initialization:
+            weight = torch.rand(self.n_hidden)
+        else:
+            weight = torch.eye(self.n_hidden)
         offset = torch.zeros(self.n_hidden)
         self.register_buffer("w", weight)
         self.register_buffer("b", offset)

--- a/mlcvs/models/nn.py
+++ b/mlcvs/models/nn.py
@@ -6,7 +6,7 @@ import torch
 from warnings import warn
 from pathlib import Path
 
-from ..utils.optim import EarlyStopping
+from ..utils.optim import EarlyStopping, LRScheduler
 from .utils import normalize,compute_mean_range
 
 
@@ -129,6 +129,7 @@ class NeuralNetworkCV(torch.nn.Module):
         # Optimizer
         self.opt_ = None
         self.earlystopping_ = None
+        self.LRScheduler_ = None
 
         # Generic attributes
         self.name_ = "NN_CV"
@@ -271,6 +272,26 @@ class NeuralNetworkCV(torch.nn.Module):
         """
         self.earlystopping_ = EarlyStopping(
             patience, min_delta, consecutive, log, save_best_model
+        )
+
+    def set_LRScheduler(self ,optimizer, patience=5, min_lr=1e-6, factor=0.9, log=False):
+        """
+        Enable LRScheduler.
+
+        Parameters
+        ----------
+        optimizer : torch.optimizer
+            the optimizer we are using
+        patience : int, optional
+            how many epochs to wait before updating the lr (default = 5)
+        min_lr: float, optional
+            least lr value to reduce to while updating (defaul = 1e-6)
+        factor: float, optional
+            factor by which the lr should be updated (default = 0.9)
+        log: bool, optional
+            print verbose info
+        """
+        self.LRScheduler_ = LRScheduler(optimizer, patience=patience, min_lr=min_lr, factor=factor, log=log
         )
 
     # Input / output standardization

--- a/mlcvs/tests/test_lda_linear.py
+++ b/mlcvs/tests/test_lda_linear.py
@@ -159,8 +159,8 @@ def test_lda_train_2d_model_harmonic(load_dataset_2d_classes,is_harmonic_lda):
     # Check PLUMED INPUT
     input = lda.plumed_input()
     expected_input = (
-        "hlda_cv: CUSTOM ARG=p.x,p.y VAR=x0,x1 FUNC=+0.689055*x0-0.724709*x1 PERIODIC=NO\n" if is_harmonic_lda
-        else "lda_cv: CUSTOM ARG=p.x,p.y VAR=x0,x1 FUNC=+0.657474*x0-0.753477*x1 PERIODIC=NO\n"
+        "hlda_cv: CUSTOM ARG=p.x,p.y VAR=x0,x1 FUNC=0.689055*x0-0.724709*x1 PERIODIC=NO\n" if is_harmonic_lda
+        else "lda_cv: CUSTOM ARG=p.x,p.y VAR=x0,x1 FUNC=0.657474*x0-0.753477*x1 PERIODIC=NO\n"
     )
     assert expected_input == input
 

--- a/mlcvs/tica/deep_tica.py
+++ b/mlcvs/tica/deep_tica.py
@@ -31,7 +31,7 @@ class DeepTICA_CV(NeuralNetworkCV):
 
     """
 
-    def __init__(self, layers, activation="relu", device = None, **kwargs):
+    def __init__(self, layers, activation="relu", random_initialization=False ,device = None, **kwargs):
         """
         Create a DeepTICA_CV object.
 
@@ -39,12 +39,14 @@ class DeepTICA_CV(NeuralNetworkCV):
         ----------
         layers : list
             Number neurons per layers.
+        random_initialization: bool
+            if initialize the weights of the network with random values uniform distributed in (0,1]
         **kwargs : dict
             Additional parameters for NeuralNetworkCV class.
         """
         
         super().__init__(
-            layers=layers, activation=activation, **kwargs 
+            layers=layers, activation=activation, random_initialization=random_initialization, **kwargs 
         )
         self.name_ = "deeptica_cv"
         self.tica = TICA()

--- a/mlcvs/tica/deep_tica.py
+++ b/mlcvs/tica/deep_tica.py
@@ -31,7 +31,7 @@ class DeepTICA_CV(NeuralNetworkCV):
 
     """
 
-    def __init__(self, layers, activation="relu", random_initialization=False ,device = None, **kwargs):
+    def __init__(self, layers, activation="relu", gaussian_random_initialization=False ,device = None, **kwargs):
         """
         Create a DeepTICA_CV object.
 
@@ -46,7 +46,7 @@ class DeepTICA_CV(NeuralNetworkCV):
         """
         
         super().__init__(
-            layers=layers, activation=activation, random_initialization=random_initialization, **kwargs 
+            layers=layers, activation=activation, gaussian_random_initialization=gaussian_random_initialization, **kwargs 
         )
         self.name_ = "deeptica_cv"
         self.tica = TICA()

--- a/mlcvs/tica/deep_tica.py
+++ b/mlcvs/tica/deep_tica.py
@@ -341,6 +341,10 @@ class DeepTICA_CV(NeuralNetworkCV):
                     raise ValueError('EarlyStopping requires validation data')
                 self.earlystopping_(loss_valid, model=self.state_dict(), epoch=ep)
 
+            # lrscheduler
+            if self.lrscheduler_ is not None:
+                self.lrscheduler_(loss_valid)
+
             # log
             print_log = False
             if ((ep + 1) % log_every == 0):

--- a/mlcvs/tica/linear_tica.py
+++ b/mlcvs/tica/linear_tica.py
@@ -74,6 +74,10 @@ class TICA_CV(LinearCV):
         if len(X) != len(t):
             raise ValueError(f'length of X is {len(X)} while length of t is {len(t)}')
 
+        # compute mean-free variables for descriptors
+        #ave = self.tica.compute_average(X,np.exp(logweights))
+        #X.sub_(ave)
+
         #define tprime if not given
         if tprime is None:
             tprime = tprime_evaluation(t, logweights)
@@ -82,6 +86,9 @@ class TICA_CV(LinearCV):
         x_t, x_lag, w_t, w_lag = find_time_lagged_configurations(X,tprime,lag)
 
         # compute mean-free variables
+        # considering all data points, this implementation must be done previously X -= average(X) 
+        #ave = self.tica.compute_average(X,np.exp(logweights))
+        # old
         ave = self.tica.compute_average(x_t,w_t)
         x_t.sub_(ave)
         x_lag.sub_(ave)

--- a/mlcvs/tica/linear_tica.py
+++ b/mlcvs/tica/linear_tica.py
@@ -8,7 +8,7 @@ import torch
 
 from .tica import TICA
 from ..models import LinearCV
-from ..utils.data import find_time_lagged_configurations
+from ..utils.data import find_time_lagged_configurations, tprime_evaluation
 
 class TICA_CV(LinearCV):
     """ Linear TICA CV.
@@ -32,7 +32,7 @@ class TICA_CV(LinearCV):
         self.name_ = "tica_cv"
         self.tica = TICA()
 
-    def fit(self, X, t = None, lag = 10, logweights = None):
+    def fit(self, X, t = None, lag = 10, logweights = None, tprime = None):
         """Fit TICA given time-lagged data (and optional weights). 
 
         Parameters
@@ -45,6 +45,8 @@ class TICA_CV(LinearCV):
             lag-time, by default 10
         logweights: array, optional
             logarithm of the weights of the configurations
+        tprime : array-like,optional
+            rescaled time estimated from the simulation. If not given 'tprime_evaluation(t,logweights)' is used instead
 
         See Also
         --------
@@ -72,21 +74,9 @@ class TICA_CV(LinearCV):
         if len(X) != len(t):
             raise ValueError(f'length of X is {len(X)} while length of t is {len(t)}')
 
-        # if weights are given, rescale the time before finding time lagged configurations
-        if logweights is not None:
-            # compute time increment in simulation time t
-            dt = np.round(t[1]-t[0],3)
-            # sanitize logweights
-            logweights = torch.Tensor(logweights)
-            logweights -= torch.max(logweights)
-            lognorm = torch.logsumexp(logweights,0)
-            logweights /= lognorm
-            # compute instantaneus time increment in rescaled time t'
-            d_tprime = torch.exp(logweights)*dt
-            # calculate cumulative time t'
-            tprime = torch.cumsum(d_tprime,0)
-        else:
-            tprime = t
+        #define tprime if not given
+        if tprime is None:
+            tprime = tprime_evaluation(t, logweights)
 
         # find time-lagged configurations
         x_t, x_lag, w_t, w_lag = find_time_lagged_configurations(X,tprime,lag)

--- a/mlcvs/tica/tica.py
+++ b/mlcvs/tica/tica.py
@@ -78,50 +78,6 @@ class TICA:
         evals, evecs = self.solve_tica_eigenproblem(C_0,C_lag,n_eig=n_eig,save_params=save_params) 
 
         return evals, evecs
-
-    def correlation_matrices(self,x,x_lag,w=None,w_lag=None):
-        """Compute the correlation matrices between x and x_lag with weights w and w_lag
-
-        Parameters
-        ----------
-        x : torch.Tensor
-            first array, from x(t=0) to x(t=T-tau) 
-        x_lag : torch.Tensor
-            second array, from x(t=tau) to x(t=T)
-        w : torch.Tensor
-            weights for x, by default None
-        w_lag : torch.Tensor
-            weights for x_lag, by default None
-
-        Returns
-        -------
-        torch.Tensor
-            correlation matrices, C(0) and C(tau)
-
-        """
-
-        if w is None: 
-            w = torch.ones(x.shape[0])
-        if w_lag is None: 
-            w_lag = torch.ones(x_lag.shape[0])
-        
-        #compute correlation matrix C0
-        corr_x = torch.einsum('ij, ik, i -> jk', x, x, w )
-        corr_x /= torch.sum(w)
-        corr_xlag = torch.einsum('ij, ik, i -> jk', x_lag, x_lag, w_lag )
-        corr_xlag /= torch.sum(w_lag)
-        # enforce symmetrization
-        C0 = 0.5*(corr_x + corr_xlag)
-
-        #compute correlation matrix Clag
-        corr_x_xlag = torch.einsum('ij, ik, i -> jk', x, x_lag, w_lag )
-        corr_x_xlag /= torch.sum(w_lag)
-        corr_xlag_x = torch.einsum('ij, ik, i -> jk', x_lag, x, w_lag )
-        corr_xlag_x /= torch.sum(w_lag)
-        # enforce symmetrization
-        Clag = 0.5*(corr_x_xlag + corr_xlag_x)
-
-        return C0,Clag
         
     def compute_correlation_matrix(self,x,y,w=None):
         """Compute the correlation matrix between x and y with weights w

--- a/mlcvs/tica/tica.py
+++ b/mlcvs/tica/tica.py
@@ -46,7 +46,7 @@ class TICA:
         
         return ave
 
-    def compute_TICA(self, data, weights = None, n_eig = 0, save_params=False):
+    def compute_TICA(self, data, weights = None, n_eig = 0, symmetrize=True, save_params=False):
         """Perform TICA computation
 
         Parameters
@@ -57,6 +57,8 @@ class TICA:
             Weights at time t and t+lag, by default None
         n_eig : int, optional
             number of eigenfunctions to compute, by default 0 = all
+        symmetrize : bool, optional
+            Enforce symmetrization, by default True
         save_params : bool, optional
             Save parameters of estimator, by default False
 
@@ -71,7 +73,7 @@ class TICA:
             w_t, w_lag = weights
 
         C_0 = self.compute_correlation_matrix(x_t,x_t,w_t)
-        C_lag = self.compute_correlation_matrix(x_t,x_lag,w_lag)
+        C_lag = self.compute_correlation_matrix(x_t,x_lag,w_lag,symmetrize=symmetrize)
         evals, evecs = self.solve_tica_eigenproblem(C_0,C_lag,n_eig=n_eig,save_params=save_params) 
 
         return evals, evecs
@@ -135,26 +137,45 @@ class TICA:
         -----
         The eigenvecs object which is returned is a matrix whose column eigvecs[:,i] is the eigenvector associated to eigvals[i]
         """ 
-        #cholesky decomposition
-        if self.reg_cholesky is not None:
-            reg = self.reg_cholesky*torch.eye(C_0.shape[0]).to(C_0.device)
-            L = torch.cholesky(C_0+reg,upper=False)
-        else:
-            L = torch.cholesky(C_0,upper=False)
-            
-        L_t = torch.t(L)
-        L_ti = torch.inverse(L_t)
-        L_i = torch.inverse(L)
-        C_new = torch.matmul(torch.matmul(L_i,C_lag),L_ti)
 
-        #find eigenvalues and vectors of C_new
-        eigvals, eigvecs = torch.symeig(C_new,eigenvectors=True)
-        #sort
-        eigvals, indices = torch.sort(eigvals, 0, descending=True)
-        eigvecs = eigvecs[:,indices]
-        
-        #return to original eigenvectors
-        eigvecs = torch.matmul(L_ti,eigvecs)
+        # if correlation matrices are symmetric the Cholesky decomposition and symeig method are used
+        if ( (C_lag.transpose(0, 1) == C_lag).all() and (C_0.transpose(0, 1) == C_0).all() ): 
+            #cholesky decomposition
+            if self.reg_cholesky is not None:
+                reg = self.reg_cholesky*torch.eye(C_0.shape[0]).to(C_0.device)
+                L = torch.cholesky(C_0+reg,upper=False)
+            else:
+                L = torch.cholesky(C_0,upper=False)
+                
+            L_t = torch.t(L)
+            L_ti = torch.inverse(L_t)
+            L_i = torch.inverse(L)
+            C_new = torch.matmul(torch.matmul(L_i,C_lag),L_ti)
+
+            #find eigenvalues and vectors of C_new
+            eigvals, eigvecs = torch.symeig(C_new,eigenvectors=True)
+
+            #sort
+            eigvals, indices = torch.sort(eigvals, 0, descending=True)
+            eigvecs = eigvecs[:,indices]
+            
+            #return to original eigenvectors
+            eigvecs = torch.matmul(L_ti,eigvecs)
+
+        else:
+            #Compute the pseudoinverse (Moore-Penrose inverse) of C_0. if det(C_0) != 0 then the usual inverse is computed
+            C_new = torch.matmul(C_lag,torch.pinverse(C_0))
+            #find eigenvalues and vectors of C_new
+            """ TODO: torch.eig() is deprecated in favor of torch.linalg.eig()  
+                      torch.linalg.eig() returns complex tensors of dtype cfloat or cdouble
+                      rather than real tensors mimicking complex tensors. 
+                      For future developments it would be necessary to take either only the real part
+                      or only the complex part or only the magnitude of the complex eigenvectors and eigenvalues """
+            eigvals, eigvecs = torch.eig(C_new,eigenvectors=True)
+
+            #sort
+            eigvals, indices = torch.sort(eigvals, 0, descending=True)
+            eigvecs = eigvecs[:,indices]
 
         #normalize them
         for i in range(eigvecs.shape[1]): # maybe change in sum along axis?
@@ -174,6 +195,7 @@ class TICA:
     
         return eigvals, eigvecs
 
+#TODO: check if t_i = - tau / \log\lambda_i or = - tau / \log \abs(\lambda_i) 
     def timescales(self, lag):
         """Return implied timescales from eigenvalues and lag-time.
 

--- a/mlcvs/tica/tica.py
+++ b/mlcvs/tica/tica.py
@@ -45,7 +45,7 @@ class TICA:
         if w is not None:
             ave = torch.einsum('ij,i ->j',x,w)/torch.sum(w)
         else:
-            ave = torch.average(x)
+            ave = torch.mean(x.T,1,keepdim=True).T
         
         return ave
 
@@ -79,6 +79,50 @@ class TICA:
 
         return evals, evecs
 
+    def correlation_matrices(self,x,x_lag,w=None,w_lag=None):
+        """Compute the correlation matrices between x and x_lag with weights w and w_lag
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            first array, from x(t=0) to x(t=T-tau) 
+        x_lag : torch.Tensor
+            second array, from x(t=tau) to x(t=T)
+        w : torch.Tensor
+            weights for x, by default None
+        w_lag : torch.Tensor
+            weights for x_lag, by default None
+
+        Returns
+        -------
+        torch.Tensor
+            correlation matrices, C(0) and C(tau)
+
+        """
+
+        if w is None: 
+            w = torch.ones(x.shape[0])
+        if w_lag is None: 
+            w_lag = torch.ones(x_lag.shape[0])
+        
+        #compute correlation matrix C0
+        corr_x = torch.einsum('ij, ik, i -> jk', x, x, w )
+        corr_x /= torch.sum(w)
+        corr_xlag = torch.einsum('ij, ik, i -> jk', x_lag, x_lag, w_lag )
+        corr_xlag /= torch.sum(w_lag)
+        # enforce symmetrization
+        C0 = 0.5*(corr_x + corr_xlag)
+
+        #compute correlation matrix Clag
+        corr_x_xlag = torch.einsum('ij, ik, i -> jk', x, x_lag, w_lag )
+        corr_x_xlag /= torch.sum(w_lag)
+        corr_xlag_x = torch.einsum('ij, ik, i -> jk', x_lag, x, w_lag )
+        corr_xlag_x /= torch.sum(w_lag)
+        # enforce symmetrization
+        Clag = 0.5*(corr_x_xlag + corr_xlag_x)
+
+        return C0,Clag
+        
     def compute_correlation_matrix(self,x,y,w=None):
         """Compute the correlation matrix between x and y with weights w
 

--- a/mlcvs/utils/data.py
+++ b/mlcvs/utils/data.py
@@ -35,6 +35,16 @@ def closest_idx_torch(array, value):
 
 # evaluation of tprime from simulation time and logweights
 def tprime_evaluation(t, logweights = None):
+    """
+    Estimate the accelerated time if a set of (log)weights is given
+
+    Parameters
+    ----------
+    t : array-like, 
+        unbias time series,    
+    logweights : array-like,optional
+        logweights to evaluate rescaled time as dt' = dt*exp(logweights)
+    """
 
     # rescale time with log-weights if given
     if logweights is not None:

--- a/mlcvs/utils/data.py
+++ b/mlcvs/utils/data.py
@@ -52,7 +52,9 @@ def tprime_evaluation(t, logweights = None):
         dt = np.round(t[1]-t[0],3)
         # sanitize logweights
         logweights = torch.Tensor(logweights)
-        logweights -= torch.max(logweights)
+        # when the bias is not deposited the value of bias potential is minimum
+        # then to have the same weight for both unbias and bias timescale 
+        logweights -= torch.min(logweights) #torch.max(logweights)
         lognorm = torch.logsumexp(logweights,0)
         logweights /= lognorm
         # compute instantaneus time increment in rescaled time t'

--- a/mlcvs/utils/data.py
+++ b/mlcvs/utils/data.py
@@ -121,7 +121,7 @@ def create_time_lagged_dataset(X, t = None, lag_time = 10, logweights = None, tp
     logweights : array-like,optional
         logweights to evaluate rescaled time as dt' = dt*exp(logweights)
     tprime : array-like,optional
-        rescaled time estimated from the simulation. If not given 'tprime_evaluation(t,logweights)' it is used instead
+        rescaled time estimated from the simulation. If not given 'tprime_evaluation(t,logweights)' is used instead
     """
 
     # check if dataframe

--- a/mlcvs/utils/data.py
+++ b/mlcvs/utils/data.py
@@ -49,7 +49,7 @@ def tprime_evaluation(t, logweights = None):
     # rescale time with log-weights if given
     if logweights is not None:
         # compute time increment in simulation time t
-        dt = np.round(t[1]-t[0],3)
+        dt = np.round(t[1]-t[0],5)
         # sanitize logweights
         logweights = torch.Tensor(logweights)
         # when the bias is not deposited the value of bias potential is minimum 
@@ -125,7 +125,7 @@ def find_time_lagged_configurations(x,t,lag):
 
     return x_t,x_lag,w_t,w_lag
 
-def create_time_lagged_dataset(X, t = None, lag_time = 10, logweights = None, tprime = None):
+def create_time_lagged_dataset(X, t = None, lag_time = 10, logweights = None, tprime = None, interval = None):
     """
     Create a dataset of time-lagged configurations. If a set of (log)weights is given the search is performed in the accelerated time.
 
@@ -141,6 +141,9 @@ def create_time_lagged_dataset(X, t = None, lag_time = 10, logweights = None, tp
         logweights to evaluate rescaled time as dt' = dt*exp(logweights)
     tprime : array-like,optional
         rescaled time estimated from the simulation. If not given 'tprime_evaluation(t,logweights)' is used instead
+    interval : list or np.array or tuple, optional
+        Range for slicing the returned dataset. Useful to work with batches of same sizes.
+        Recall that with different lag_times one obtains different datasets, with different lengths 
     """
 
     # check if dataframe
@@ -163,6 +166,15 @@ def create_time_lagged_dataset(X, t = None, lag_time = 10, logweights = None, tp
 
     # find pairs of configurations separated by lag_time
     data = find_time_lagged_configurations(X, tprime,lag=lag_time)
+
+    if interval is not None:
+        # covert to a list
+        data = list(data)
+        # assert dimension of interval
+        assert len(interval) == 2
+        # modifies the content of data by slicing
+        for i in range(len(data)):
+            data[i] = data[i][interval[0]:interval[1]]
 
     #return data
     return torch.utils.data.TensorDataset(*data)

--- a/mlcvs/utils/data.py
+++ b/mlcvs/utils/data.py
@@ -52,9 +52,8 @@ def tprime_evaluation(t, logweights = None):
         dt = np.round(t[1]-t[0],3)
         # sanitize logweights
         logweights = torch.Tensor(logweights)
-        # when the bias is not deposited the value of bias potential is minimum
-        # then to have the same weight for both unbias and bias timescale 
-        logweights -= torch.min(logweights) #torch.max(logweights)
+        # when the bias is not deposited the value of bias potential is minimum 
+        logweights -= torch.max(logweights)
         lognorm = torch.logsumexp(logweights,0)
         logweights /= lognorm
         # compute instantaneus time increment in rescaled time t'

--- a/mlcvs/utils/data.py
+++ b/mlcvs/utils/data.py
@@ -54,6 +54,14 @@ def tprime_evaluation(t, logweights = None):
         logweights = torch.Tensor(logweights)
         # when the bias is not deposited the value of bias potential is minimum 
         logweights -= torch.max(logweights)
+        # bug: exp(logweights/lognorm) != exp(logweights)/norm, where norm is sum_i beta V_i
+        # are we changing the temperature? 
+        """ possibilities:
+            1) logweights /= torch.min(logweights) -> logweights belong to [0,1] 
+            2) pass beta as an argument, then logweights *= beta
+            3) tprime = dt * torch.cumsum( torch.exp( torch.logsumexp(logweights,0) ) ,0)
+            4) tprime = dt *torch.exp ( torch.log (torch.cumsum (torch.exp(logweights) ) ) )
+        """
         lognorm = torch.logsumexp(logweights,0)
         logweights /= lognorm
         # compute instantaneus time increment in rescaled time t'

--- a/mlcvs/utils/data.py
+++ b/mlcvs/utils/data.py
@@ -184,7 +184,7 @@ class FastTensorDataLoader:
 
         Parameters
         ----------
-        tensors : list of tensors or torch.Dataset or torch.Subset object containing a tensors object
+        tensors : list of tensors or torch.Dataset or torch.Subset or list of torch.Subset object containing a tensors object
             tensors to store. Must have the same length @ dim 0.
         batch_size : int, optional
             batch size, by default 0 (==single batch)
@@ -204,6 +204,18 @@ class FastTensorDataLoader:
             tensors = [ tensors.tensors[i] for i in range(len(tensors.tensors)) ]
         elif type(tensors) == Subset:
             tensors = [ tensors.dataset.tensors[i][tensors.indices] for i in range(len(tensors.dataset.tensors)) ]
+        # check for input type list of Subset, and create a list of tensors
+        elif (type(tensors) == list and type(tensors[0]) == Subset ):
+            new_tensors = []
+            tensor = torch.Tensor()
+            for j in range( len( tensors[0].dataset.tensors ) ):
+                for i in range( len( tensors ) ):
+                    if i == 0:
+                        tensor = tensors[i].dataset.tensors[j][tensors[i].indices]
+                    else:    
+                        tensor = torch.cat( (tensor, tensors[i].dataset.tensors[j][tensors[i].indices]), 0 )
+                new_tensors.append(tensor)
+            tensors = new_tensors
 
         assert all(t.shape[0] == tensors[0].shape[0] for t in tensors)
         self.tensors = tensors


### PR DESCRIPTION
## Description
- [ ] definition of `tprime_evaluation` function outside `create_time_lagged_dataset` function.  
- [ ] Now it's possible to pass a **tprime** argument (optional) to `create_time_lagged_dataset`. If not passed then the rescaled time is computed from the **unbias time** and **logweights**      
- [ ] Attribute **symmetrize** added to `TICA` object. Default value set to `True`, and enforce the symmetrization of Correlation matrices. If set to `False` the `Compute_TICA` function solve the TICA problem without symmetrizing `C_tau` 

## Todos
  - check what happens if the correlation matrices are not symmetric

## Questions
- [ ] The dataset is composed by the correlated couples ( x_i(t) , x_i(t+lag) ). When the data is divided between training set and validation set (`RandomSplit`) what does it happen to the **time ordering** of this set? is the correlation matrix computed properly? the **time ordering** is not important (the correlation matrix is simply a weighted average), but dividing the whole dataset into two different datasets may lead to different estimation of both `C_tau` and `C_0`, compared to the estimation obtained by using the whole dataset.  
- [ ] what does it happend if the eigenvales and eigenfunctions are complex ? 

## Status
- [ ] Ready to go