### PR TITLE
add option in ae/vae to compare output of the decoder with a different target

### DIFF
--- a/mlcvs/core/loss/elbo.py
+++ b/mlcvs/core/loss/elbo.py
@@ -25,8 +25,8 @@ from mlcvs.core.loss.mse import MSE_loss
 # =============================================================================
 
 def elbo_gaussians_loss(
-        input: torch.Tensor,
         target: torch.Tensor,
+        output: torch.Tensor,
         mean: torch.Tensor,
         log_variance: torch.Tensor,
         weights: Optional[torch.Tensor] = None
@@ -40,8 +40,8 @@ def elbo_gaussians_loss(
 
     Parameters
     ----------
-    input : torch.Tensor
-        Shape ``(n_batches, in_features)``. Input of the encoder.
+    target : torch.Tensor
+        Shape ``(n_batches, in_features)``. Data points (e.g. input of encoder or time-lagged features).
     output : torch.Tensor
         Shape ``(n_batches, in_features)``. Output of the decoder.        
     mean : torch.Tensor
@@ -51,7 +51,7 @@ def elbo_gaussians_loss(
         Shape ``(n_batches, latent_features)``. The logarithm of the variances
         of the Gaussian distributions associated to the inputs.
     weights : torch.Tensor, optional
-        Shape ``(n_batches,)`. If given, the average over batches is weighted.
+        Shape ``(n_batches,)`` or ``(n_batches,1)``. If given, the average over batches is weighted.
         The default (``None``) is unweighted.
 
     Returns
@@ -67,9 +67,12 @@ def elbo_gaussians_loss(
     if weights is None:
         kl = kl.mean()
     else:
+        weights = weights.squeeze()
+        if weights.shape != kl.shape:
+            raise ValueError(f'weights should be a tensor of shape (n_batches,) or (n_batches,1), not {weights.shape}.')
         kl = (kl * weights).sum()
 
     # Reconstruction loss.
-    reconstruction = MSE_loss(input, target, weights=weights)
+    reconstruction = MSE_loss(output, target, weights=weights)
 
     return reconstruction + kl

--- a/mlcvs/cvs/unsupervised/vae.py
+++ b/mlcvs/cvs/unsupervised/vae.py
@@ -192,7 +192,7 @@ class VAE_CV(BaseCV, pl.LightningModule):
             x_ref = x 
 
         # Loss function.
-        loss = self.loss_fn(x_hat, x_ref, mean, log_variance, **options)
+        loss = self.loss_fn(x_ref, x_hat, mean, log_variance, **options)
 
         # Log.
         name = 'train' if self.training else 'valid'       

--- a/mlcvs/cvs/unsupervised/vae.py
+++ b/mlcvs/cvs/unsupervised/vae.py
@@ -182,13 +182,17 @@ class VAE_CV(BaseCV, pl.LightningModule):
         if 'weights' in train_batch:
             options['weights'] = train_batch['weights']
 
-        # TODO: Should we do preprocessing here?
-
         # Encode/decode.
         mean, log_variance, x_hat = self.encode_decode(x)
 
+        # Reference output (compare with a 'target' key if any, otherwise with input 'data')
+        if 'target' in train_batch:
+            x_ref = train_batch['target']
+        else:
+            x_ref = x 
+
         # Loss function.
-        loss = self.loss_fn(x, x_hat, mean, log_variance, **options)
+        loss = self.loss_fn(x_hat, x_ref, mean, log_variance, **options)
 
         # Log.
         name = 'train' if self.training else 'valid'       


### PR DESCRIPTION
## Description
I added a small feature to the training step of AE/VAE cvs to allow comparing the output of the decoder not only with the input data but also with different quantities (e.g. time-lagged data).

If a 'target' key is available in the dictionary it will be used in the reconstruction loss, otherwise 'data' is used.

@andrrizzi

## Status
- [X] Ready to go