### PR TITLE
Implement Loss classes, some PEP8 fixes

### DIFF
--- a/mlcvs/core/loss/__init__.py
+++ b/mlcvs/core/loss/__init__.py
@@ -1,9 +1,9 @@
 __all__ = ["mse_loss","tda_loss","elbo_gaussians_loss","reduce_eigenvalues_loss","autocorrelation_loss","fisher_discriminant_loss"]
 
-from .mse import mse_loss
-from .tda_loss import tda_loss
-from .eigvals import reduce_eigenvalues_loss
-from .elbo import elbo_gaussians_loss
-from .autocorrelation import autocorrelation_loss
-from .fisher import fisher_discriminant_loss
+from .mse import MSELoss, mse_loss
+from .tda_loss import TDALoss, tda_loss
+from .eigvals import ReduceEigenvaluesLoss, reduce_eigenvalues_loss
+from .elbo import ELBOGaussiansLoss, elbo_gaussians_loss
+from .autocorrelation import AutocorrelationLoss, autocorrelation_loss
+from .fisher import FisherDiscriminantLoss, fisher_discriminant_loss
 

--- a/mlcvs/core/loss/__init__.py
+++ b/mlcvs/core/loss/__init__.py
@@ -1,4 +1,11 @@
-__all__ = ["mse_loss","tda_loss","elbo_gaussians_loss","reduce_eigenvalues_loss","autocorrelation_loss","fisher_discriminant_loss"]
+__all__ = [
+    "MSELoss", "mse_loss",
+    "TDALoss", "tda_loss",
+    "ELBOGaussiansLoss", "elbo_gaussians_loss",
+    "ReduceEigenvaluesLoss", "reduce_eigenvalues_loss",
+    "AutocorrelationLoss", "autocorrelation_loss",
+    "FisherDiscriminantLoss", "fisher_discriminant_loss",
+]
 
 from .mse import MSELoss, mse_loss
 from .tda_loss import TDALoss, tda_loss

--- a/mlcvs/core/loss/eigvals.py
+++ b/mlcvs/core/loss/eigvals.py
@@ -1,67 +1,153 @@
+#!/usr/bin/env python
+
+# =============================================================================
+# MODULE DOCSTRING
+# =============================================================================
+
+"""
+Reduce eigenvalues loss.
+"""
+
+__all__ = ['ReduceEigenvaluesLoss', 'reduce_eigenvalues_loss']
+
+
+# =============================================================================
+# GLOBAL IMPORTS
+# =============================================================================
+
 import torch
 
-__all__ = ['reduce_eigenvalues_loss']
 
-def reduce_eigenvalues_loss( evals : torch.Tensor, mode = 'sum', n_eig = 0, invert_sign = True ):
-        """
-        Calculate a monotonic function f(x) of the eigenvalues, by default the sum. By default it returns -f(x) to be used as loss function to maximize eigenvalues in gradient descent schemes. 
+# =============================================================================
+# LOSS FUNCTIONS
+# =============================================================================
+
+class ReduceEigenvaluesLoss(torch.nn.Module):
+    """Calculate a monotonic function f(x) of the eigenvalues, by default the sum.
+
+    By default it returns -f(x) to be used as loss function to maximize
+    eigenvalues in gradient descent schemes.
+
+    The following reduce functions are implemented:
+        - sum     : sum_i (lambda_i)
+        - sum2    : sum_i (lambda_i)**2
+        - gap     : (lambda_1-lambda_2)
+        - its     : sum_i (1/log(lambda_i))
+        - single  : (lambda_i)
+        - single2 : (lambda_i)**2
+
+    """
+
+    def __init__(
+            self,
+            mode: str = 'sum',
+            n_eig: int = 0,
+            invert_sign: bool = True,
+    ):
+        """Constructor.
 
         Parameters
         ----------
-        eval : torch.Tensor
-            Eigenvalues
-        mode : str
-            function of the eigenvalues to optimize (see notes)
+        mode : str, optional
+            Function of the eigenvalues to optimize (see notes). Default is ``'sum'``.
         n_eig: int, optional
-            number of eigenvalues to include in the loss (default: 0 --> all). in case of single and single2 is used to specify which eigenvalue to use.
+            Number of eigenvalues to include in the loss (default: 0 --> all).
+            In case of ``'single'`` and ``'single2'`` is used to specify which
+            eigenvalue to use.
         invert_sign: bool, optional
-            whether to return the opposite of the function (in order to minized with GD methods), default tru
-            
-        Notes
-        -----
-        The following mode are implemented:
-            - sum     : sum_i (lambda_i)
-            - sum2    : sum_i (lambda_i)**2
-            - gap     : (lambda_1-lambda_2)
-            - its     : sum_i (1/log(lambda_i))
-            - single  : (lambda_i)
-            - single2 : (lambda_i)**2
+            Whether to return the opposite of the function (in order to be minimized
+            with GD methods). Default is ``True``.
+        """
+        super().__init__()
+        self.mode = mode
+        self.n_eig = n_eig
+        self.invert_sign = invert_sign
+
+    def forward(self, evals: torch.Tensor) -> torch.Tensor:
+        """Compute the loss.
+
+        Parameters
+        ----------
+        evals : torch.Tensor
+            Shape ``(n_batches, n_eigenvalues)``. Eigenvalues.
 
         Returns
         -------
-        loss : torch.Tensor (scalar)
-            score
+        loss : torch.Tensor
         """
+        return reduce_eigenvalues_loss(evals, self.mode, self.n_eig, self.invert_sign)
 
-        #check if n_eig is given and
-        if (n_eig>0) & (len(evals) < n_eig):
-            raise ValueError("n_eig must be lower than the number of eigenvalues.")
-        elif (n_eig==0):
-            if ( (mode == 'single') | (mode == 'single2')):
-                raise ValueError("n_eig must be specified when using single or single2.")
-            else:
-                n_eig = len(evals)
 
-        loss = None
-        
-        if   mode == 'sum':
-            loss =  torch.sum(evals[:n_eig])
-        elif mode == 'sum2':
-            g_lambda =  torch.pow(evals,2)
-            loss = torch.sum(g_lambda[:n_eig])
-        elif mode == 'gap':
-            loss =  (evals[0] -evals[1])
-        elif mode == 'its':
-            g_lambda = 1 / torch.log(evals)
-            loss = torch.sum(g_lambda[:n_eig])
-        elif mode == 'single':
-            loss =  evals[n_eig-1]
-        elif mode == 'single2':
-            loss = torch.pow(evals[n_eig-1],2)
+def reduce_eigenvalues_loss(
+        evals: torch.Tensor,
+        mode: str = 'sum',
+        n_eig: int = 0,
+        invert_sign: bool = True,
+) -> torch.Tensor:
+    """Calculate a monotonic function f(x) of the eigenvalues, by default the sum.
+
+    By default it returns -f(x) to be used as loss function to maximize
+    eigenvalues in gradient descent schemes.
+
+    Parameters
+    ----------
+    evals : torch.Tensor
+        Shape ``(n_batches, n_eigenvalues)``. Eigenvalues.
+    mode : str, optional
+        Function of the eigenvalues to optimize (see notes). Default is ``'sum'``.
+    n_eig: int, optional
+        Number of eigenvalues to include in the loss (default: 0 --> all).
+        In case of ``'single'`` and ``'single2'`` is used to specify which
+        eigenvalue to use.
+    invert_sign: bool, optional
+        Whether to return the opposite of the function (in order to be minimized
+        with GD methods). Default is ``True``.
+
+    Notes
+    -----
+    The following functions are implemented:
+        - sum     : sum_i (lambda_i)
+        - sum2    : sum_i (lambda_i)**2
+        - gap     : (lambda_1-lambda_2)
+        - its     : sum_i (1/log(lambda_i))
+        - single  : (lambda_i)
+        - single2 : (lambda_i)**2
+
+    Returns
+    -------
+    loss : torch.Tensor (scalar)
+        Loss value.
+    """
+
+    #check if n_eig is given and
+    if (n_eig>0) & (len(evals) < n_eig):
+        raise ValueError("n_eig must be lower than the number of eigenvalues.")
+    elif (n_eig==0):
+        if ( (mode == 'single') | (mode == 'single2')):
+            raise ValueError("n_eig must be specified when using single or single2.")
         else:
-            raise ValueError(f"unknown mode : {mode}. options: 'sum','sum2','gap','single','its'.")
+            n_eig = len(evals)
 
-        if invert_sign:
-            loss *= -1
+    loss = None
 
-        return loss
+    if   mode == 'sum':
+        loss =  torch.sum(evals[:n_eig])
+    elif mode == 'sum2':
+        g_lambda =  torch.pow(evals,2)
+        loss = torch.sum(g_lambda[:n_eig])
+    elif mode == 'gap':
+        loss =  (evals[0] -evals[1])
+    elif mode == 'its':
+        g_lambda = 1 / torch.log(evals)
+        loss = torch.sum(g_lambda[:n_eig])
+    elif mode == 'single':
+        loss =  evals[n_eig-1]
+    elif mode == 'single2':
+        loss = torch.pow(evals[n_eig-1],2)
+    else:
+        raise ValueError(f"unknown mode : {mode}. options: 'sum','sum2','gap','single','its'.")
+
+    if invert_sign:
+        loss *= -1
+
+    return loss

--- a/mlcvs/core/loss/elbo.py
+++ b/mlcvs/core/loss/elbo.py
@@ -8,7 +8,7 @@
 Evidence Lower BOund (ELBO) loss functions used to train variational Autoencoders.
 """
 
-__all__ = ['elbo_gaussians_loss']
+__all__ = ['ELBOGaussiansLoss', 'elbo_gaussians_loss']
 
 
 # =============================================================================
@@ -24,13 +24,56 @@ from mlcvs.core.loss.mse import mse_loss
 # LOSS FUNCTIONS
 # =============================================================================
 
+class ELBOGaussiansLoss(torch.nn.Module):
+    """ELBO loss function assuming the latent and reconstruction distributions are Gaussian.
+
+    The ELBO uses the MSE as the reconstruction loss (i.e., assumes that the
+    decoder outputs the mean of a Gaussian distribution with variance 1), and
+    the KL divergence between two normal distributions ``N(mean, var)`` and
+    ``N(0, 1)``, where ``mean`` and ``var`` are the output of the encoder.
+    """
+    def forward(
+            self,
+            target: torch.Tensor,
+            output: torch.Tensor,
+            mean: torch.Tensor,
+            log_variance: torch.Tensor,
+            weights: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        """Compute the value of the loss function.
+
+        Parameters
+        ----------
+        target : torch.Tensor
+            Shape ``(n_batches, in_features)``. Data points (e.g. input of encoder
+            or time-lagged features).
+        output : torch.Tensor
+            Shape ``(n_batches, in_features)``. Output of the decoder.
+        mean : torch.Tensor
+            Shape ``(n_batches, latent_features)``. The means of the Gaussian
+            distributions associated to the inputs.
+        log_variance : torch.Tensor
+            Shape ``(n_batches, latent_features)``. The logarithm of the variances
+            of the Gaussian distributions associated to the inputs.
+        weights : torch.Tensor, optional
+            Shape ``(n_batches,)`` or ``(n_batches,1)``. If given, the average over
+            batches is weighted. The default (``None``) is unweighted.
+
+        Returns
+        -------
+        loss: torch.Tensor
+            The value of the loss function.
+        """
+        return elbo_gaussians_loss(target, output, mean, log_variance, weights)
+
+
 def elbo_gaussians_loss(
         target: torch.Tensor,
         output: torch.Tensor,
         mean: torch.Tensor,
         log_variance: torch.Tensor,
         weights: Optional[torch.Tensor] = None
-):
+) -> torch.Tensor:
     """ELBO loss function assuming the latent and reconstruction distributions are Gaussian.
 
     The ELBO uses the MSE as the reconstruction loss (i.e., assumes that the
@@ -41,7 +84,8 @@ def elbo_gaussians_loss(
     Parameters
     ----------
     target : torch.Tensor
-        Shape ``(n_batches, in_features)``. Data points (e.g. input of encoder or time-lagged features).
+        Shape ``(n_batches, in_features)``. Data points (e.g. input of encoder
+        or time-lagged features).
     output : torch.Tensor
         Shape ``(n_batches, in_features)``. Output of the decoder.        
     mean : torch.Tensor
@@ -51,8 +95,8 @@ def elbo_gaussians_loss(
         Shape ``(n_batches, latent_features)``. The logarithm of the variances
         of the Gaussian distributions associated to the inputs.
     weights : torch.Tensor, optional
-        Shape ``(n_batches,)`` or ``(n_batches,1)``. If given, the average over batches is weighted.
-        The default (``None``) is unweighted.
+        Shape ``(n_batches,)`` or ``(n_batches,1)``. If given, the average over
+        batches is weighted. The default (``None``) is unweighted.
 
     Returns
     -------

--- a/mlcvs/core/loss/fisher.py
+++ b/mlcvs/core/loss/fisher.py
@@ -1,26 +1,85 @@
+#!/usr/bin/env python
+
+# =============================================================================
+# MODULE DOCSTRING
+# =============================================================================
+
+"""
+Fisher discriminant loss for (Deep) Linear Discriminant Analysis.
+"""
+
+__all__ = ['FisherDiscriminantLoss', 'fisher_discriminant_loss']
+
+
+# =============================================================================
+# GLOBAL IMPORTS
+# =============================================================================
+
 import torch
 from mlcvs.core.stats import LDA
 
-__all__ = ['fisher_discriminant_loss']
 
-def fisher_discriminant_loss(X : torch.Tensor, labels : torch.Tensor, invert_sign = True):
+# =============================================================================
+# LOSS FUNCTIONS
+# =============================================================================
+
+class FisherDiscriminantLoss(torch.nn.Module):
     """ Fisher's discriminant ratio.
 
-    $$L = - \frac{S_b(X)}{S_w(X)}$$
+    .. math::
+        L = - \frac{S_b(X)}{S_w(X)}
+    """
+
+    def __init__(self, invert_sign : bool = True):
+        super().__init__()
+        self.invert_sign = invert_sign
+
+    def forward(
+            self,
+            X: torch.Tensor,
+            labels: torch.Tensor,
+    ) -> torch.Tensor:
+        """Compute the value of the loss function.
+
+        Parameters
+        ----------
+        X : torch.Tensor
+            Shape ``(n_batches, n_features)``. Input features.
+        labels : torch.Tensor
+            Shape ``(n_batches,)``. Classes labels.
+
+        Returns
+        -------
+        loss : torch.Tensor
+            Loss value.
+        """
+        return fisher_discriminant_loss(X, labels. self.invert_sign)
+
+
+def fisher_discriminant_loss(
+        X: torch.Tensor,
+        labels: torch.Tensor,
+        invert_sign: bool = True
+) -> torch.Tensor:
+    """ Fisher's discriminant ratio.
+
+    .. math::
+        L = - \frac{S_b(X)}{S_w(X)}
     
     Parameters
     ----------
     X : torch.Tensor
-        input variable
+        Shape ``(n_batches, n_features)``. Input features.
     labels : torch.Tensor
-        classes labels
+        Shape ``(n_batches,)``. Classes labels.
     invert_sign: bool, optional
-        whether to return the opposite of the function (in order to be minimized with GD methods), by default true
+        whether to return the negative Fisher's discriminant ratio in order to be
+        minimized with gradient descent methods. Default is ``True``.
 
     Returns
     -------
     loss: torch.Tensor
-        loss function
+        Loss value.
     """
 
     if X.ndim == 1:
@@ -33,7 +92,7 @@ def fisher_discriminant_loss(X : torch.Tensor, labels : torch.Tensor, invert_sig
     n_classes = len(labels.unique())
 
     # define LDA object to compute S_b / S_w ratio
-    lda = LDA(in_features=d,n_states=n_classes)
+    lda = LDA(in_features=d, n_states=n_classes)
 
     s_b, s_w = lda.compute_scatter_matrices(X,labels)
 

--- a/mlcvs/core/loss/mse.py
+++ b/mlcvs/core/loss/mse.py
@@ -1,8 +1,47 @@
+#!/usr/bin/env python
+
+# =============================================================================
+# MODULE DOCSTRING
+# =============================================================================
+
+"""
+(Weighted) Mean Squared Error (MSE) loss function.
+"""
+
+__all__ = ['MSELoss', 'mse_loss']
+
+
+# =============================================================================
+# GLOBAL IMPORTS
+# =============================================================================
+
+from typing import Optional
+
 import torch
 
-__all__ = ['mse_loss']
 
-def mse_loss(input : torch.Tensor, target : torch.Tensor, weights = None):
+# =============================================================================
+# LOSS FUNCTIONS
+# =============================================================================
+
+class MSELoss(torch.nn.Module):
+    """(Weighted) Mean Square Error"""
+
+    def forward(
+            self,
+            input: torch.Tensor,
+            target: torch.Tensor,
+            weights: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        """Compute the value of the loss function."""
+        return mse_loss(input, target, weights)
+
+
+def mse_loss(
+        input: torch.Tensor,
+        target: torch.Tensor,
+        weights: Optional[torch.Tensor] = None
+) -> torch.Tensor:
     """(Weighted) Mean Square Error
 
     Parameters
@@ -25,7 +64,7 @@ def mse_loss(input : torch.Tensor, target : torch.Tensor, weights = None):
     if target.ndim == 1:
         target = target.unsqueeze(1)
     # take the different
-    diff = input - target 
+    diff = input - target
     # weight them
     if weights is not None:
         if weights.ndim == 1:

--- a/mlcvs/core/loss/tda_loss.py
+++ b/mlcvs/core/loss/tda_loss.py
@@ -1,45 +1,122 @@
-import torch
+#!/usr/bin/env python
+
+# =============================================================================
+# MODULE DOCSTRING
+# =============================================================================
+
+"""
+(Weighted) Mean Squared Error (MSE) loss function.
+"""
+
+__all__ = ['TDALoss', 'tda_loss']
+
+
+# =============================================================================
+# GLOBAL IMPORTS
+# =============================================================================
+
+from typing import Union
 from warnings import warn
 
-__all__ = ["tda_loss"]
+import torch
 
-def tda_loss(H : torch.Tensor,
-            labels : torch.Tensor,
-            n_states : int,
-            target_centers : list or torch.Tensor,
-            target_sigmas : list or torch.Tensor,
-            alfa : float = 1,
-            beta : float = 100) -> torch.Tensor:
+
+# =============================================================================
+# LOSS FUNCTIONS
+# =============================================================================
+
+class TDALoss(torch.nn.Module):
+    """Compute a loss function as the distance from a simple Gaussian target distribution."""
+
+    def __init__(
+            self,
+            n_states: int,
+            target_centers: Union[list, torch.Tensor],
+            target_sigmas: Union[list, torch.Tensor],
+            alfa: float = 1,
+            beta: float = 100,
+    ):
+        """Constructor.
+
+        Parameters
+        ----------
+        n_states : int
+            Number of states. The integer labels are expected to be in between 0
+            and ``n_states-1``.
+        target_centers : list or torch.Tensor
+            Shape ``(n_states, n_cvs)``. Centers of the Gaussian targets.
+        target_sigmas : list or torch.Tensor
+            Shape ``(n_states, n_cvs)``. Standard deviations of the Gaussian targets.
+        alfa : float, optional
+            Centers_loss component prefactor, by default 1.
+        beta : float, optional
+            Sigmas loss compontent prefactor, by default 100.
+        """
+        self.n_states = n_states
+        self.target_centers = target_centers
+        self.target_sigmas = target_sigmas
+        self.alfa = alfa
+        self.beta = beta
+
+    def forward(
+            self,
+            H: torch.Tensor,
+            labels: torch.Tensor,
+    ) -> torch.Tensor:
+        """Compute the value of the loss function.
+
+        Parameters
+        ----------
+        H : torch.Tensor
+            Shape ``(n_batches, n_features)``. Output of the NN.
+        labels : torch.Tensor
+            Shape ``(n_batches,)``. Labels of the dataset.
+
+        Returns
+        -------
+        loss : torch.Tensor
+            Loss value.
+        """
+        return tda_loss(H, labels, self.n_states, self.target_centers, self.target_sigmas, self.alfa, self.beta)
+
+
+def tda_loss(
+        H: torch.Tensor,
+        labels: torch.Tensor,
+        n_states: int,
+        target_centers: Union[list, torch.Tensor],
+        target_sigmas: Union[list, torch.Tensor],
+        alfa: float = 1,
+        beta: float = 100,
+) -> torch.Tensor:
     """
     Compute a loss function as the distance from a simple Gaussian target distribution.
     
     Parameters
     ----------
     H : torch.Tensor
-        Output of the NN
+        Shape ``(n_batches, n_features)``. Output of the NN.
     labels : torch.Tensor
-        Labels of the dataset
+        Shape ``(n_batches,)``. Labels of the dataset.
     n_states : int
-        Number of states in the target
+        The integer labels are expected to be in between 0 and ``n_states-1``.
     target_centers : list or torch.Tensor
-        Centers of the Gaussian targets
-        Shape: (n_states, n_cvs)
+        Shape ``(n_states, n_cvs)``. Centers of the Gaussian targets.
     target_sigmas : list or torch.Tensor
-        Standard deviations of the Gaussian targets
-        Shape: (n_states, n_cvs)
+        Shape ``(n_states, n_cvs)``. Standard deviations of the Gaussian targets.
     alfa : float, optional
-        Centers_loss component prefactor, by default 1
+        Centers_loss component prefactor, by default 1.
     beta : float, optional
-        Sigmas loss compontent prefactor, by default 100
+        Sigmas loss compontent prefactor, by default 100.
 
     Returns
     -------
     torch.Tensor
-        Total loss, centers loss, sigmas loss
+        Total loss, centers loss, and sigmas loss.
     """
-    if not isinstance(target_centers,torch.Tensor):
+    if not isinstance(target_centers, torch.Tensor):
         target_centers = torch.Tensor(target_centers)
-    if not isinstance(target_sigmas,torch.Tensor):
+    if not isinstance(target_sigmas, torch.Tensor):
         target_sigmas = torch.Tensor(target_sigmas)
     
     loss_centers = torch.zeros_like(target_centers)
@@ -62,12 +139,10 @@ def tda_loss(H : torch.Tensor,
         # compute loss function contributes for class i
         loss_centers[i] = alfa*(mu - target_centers[i]).pow(2)
         loss_sigmas[i] = beta*(sigma - target_sigmas[i]).pow(2)
-        
-        
+
     # get total model loss   
     loss_centers = torch.sum(loss_centers)
     loss_sigmas = torch.sum(loss_sigmas) 
     loss = loss_centers + loss_sigmas  
 
     return loss, loss_centers, loss_sigmas
-

--- a/mlcvs/cvs/cv.py
+++ b/mlcvs/cvs/cv.py
@@ -94,7 +94,7 @@ class BaseCV:
             if isinstance(getattr(self,b), Transform): 
                 getattr(self,b).setup_from_datamodule(datamodule)
 
-    def forward(self, x : torch.Tensor) -> (torch.Tensor):
+    def forward(self, x : torch.Tensor) -> torch.Tensor:
         """
         Evaluation of the CV
 
@@ -123,7 +123,7 @@ class BaseCV:
 
         return x
 
-    def forward_cv(self, x : torch.Tensor) -> (torch.Tensor):
+    def forward_cv(self, x : torch.Tensor) -> torch.Tensor:
         """
         Execute sequentially all the blocks in self.BLOCKS unless they are not initialized.
         

--- a/mlcvs/cvs/supervised/regression.py
+++ b/mlcvs/cvs/supervised/regression.py
@@ -106,6 +106,7 @@ def test_regression_cv():
     print('weighted loss') 
     w = torch.randn((100))
     dataset = DictionaryDataset({'data':X,'target':y,'weights':w})
+    datamodule = DictionaryDataModule(dataset, lengths=[0.75,0.2,0.05], batch_size=25)
     trainer.fit( model, datamodule )
         
     # use custom loss

--- a/mlcvs/cvs/supervised/regression.py
+++ b/mlcvs/cvs/supervised/regression.py
@@ -105,9 +105,9 @@ def test_regression_cv():
     # weighted loss
     print('weighted loss') 
     w = torch.randn((100))
-    dataset = DictionaryDataset({'data':X,'target':y,'weights':w})
-    datamodule = DictionaryDataModule(dataset, lengths=[0.75,0.2,0.05], batch_size=25)
-    trainer.fit( model, datamodule )
+    dataset_weights = DictionaryDataset({'data':X, 'target':y, 'weights':w})
+    datamodule_weights = DictionaryDataModule(dataset, lengths=[0.75,0.2,0.05], batch_size=25)
+    trainer.fit(model, datamodule_weights)
         
     # use custom loss
     print('custom loss')


### PR DESCRIPTION
## Description
- Implements the class version of all loss functions.
- Fixes the ``RegressionCV`` tests that were not testing weights.
- Some PEP8 fixes (mostly spaces).
- Some docstring extensions.

This PR shouldn't break anything, and it is already quite big so I'm going to merge it and implement the switch from functional to class loss functions in ``cvs`` in a separate PR.
