### PR TITLE
Switch from functional to class losses

### DIFF
--- a/docs/notebooks/cvs_DeepTICA.ipynb
+++ b/docs/notebooks/cvs_DeepTICA.ipynb
@@ -200,12 +200,10 @@
     "from mlcvs.cvs import DeepTICA\n",
     "\n",
     "n_components = 2\n",
-    "nn_layers = [2,15,15,n_components]\n",
-    "nn_args = {'activation': 'shifted_softplus'}\n",
-    "loss_args = {'mode':'sum2'}\n",
-    "options= {'nn': nn_args, 'loss':loss_args}\n",
+    "nn_layers = [2, 15, 15, n_components]\n",
+    "options= {'nn': {'activation': 'shifted_softplus'}}\n",
     "\n",
-    "model = DeepTICA (nn_layers, options=options )\n",
+    "model = DeepTICA(nn_layers, options=options)\n",
     "model"
    ]
   },
@@ -911,12 +909,11 @@
     "from mlcvs.cvs import DeepTICA\n",
     "\n",
     "n_components = 3\n",
-    "nn_layers = [2,15,15,n_components]\n",
-    "nn_args = {'activation': 'shifted_softplus'}\n",
-    "loss_args = {'mode':'sum'}\n",
-    "options= {'nn': nn_args, 'loss':loss_args}\n",
+    "nn_layers = [2, 15, 15, n_components]\n",
+    "options= {'nn': {'activation': 'shifted_softplus'}}\n",
     "\n",
-    "model = DeepTICA (nn_layers, options=options )\n",
+    "model = DeepTICA(nn_layers, options=options)\n",
+    "model.loss_fn.mode = 'sum'\n",
     "model"
    ]
   },

--- a/docs/notebooks/intro_3_loss_optim.ipynb
+++ b/docs/notebooks/intro_3_loss_optim.ipynb
@@ -88,7 +88,7 @@
     "2. the calculation of the loss function\n",
     "3. a backward pass\n",
     "\n",
-    "The general workflow cannot be changed as it is specific to each CV, unless you subclass a given CV and overload the `training_step` method. However, there are some details that can be changed by interacting with the `loss_fn` and `loss_kwargs` members. "
+    "The general workflow cannot be changed as it is specific to each CV, unless you subclass a given CV and overload the `training_step` method. However, there are some details that can be changed."
    ]
   },
   {
@@ -140,9 +140,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Another setting which can be customized is the one in which the loss function has some options which can be customized. For instance, in the case of DeepLDA/DeepTICA CVs the loss function is `reduce_eigenvalues_loss` which takes as inputs the eigenvalues of the underlying statistical problem and return a scalar (e.g. the sum of eigenvalues squared). To see the variables that can be set you should look at the documentation of the loss functions used. The new arguments should be saved in the dictionary with keyword arguments contained in the `loss_kwargs` member:\n",
+    "Another setting which can be customized is the one in which the loss function has some options which can be customized. For instance, in the case of DeepLDA/DeepTICA CVs the loss function is `ReduceEigenvaluesLoss` which takes as inputs the eigenvalues of the underlying statistical problem and return a scalar (e.g. the sum of eigenvalues squared). To see the variables that can be set you should look at the documentation of the loss functions used.\n",
     "\n",
-    "For example, to change the reduction mode to the sum of the eigenvalues instead of the sum of the squared ones, one can update the dictionary accordingly:"
+    "For example, to change the reduction mode to the sum of the eigenvalues instead of the sum of the squared ones, one can update the loss function accordingly:"
    ]
   },
   {
@@ -163,16 +163,16 @@
     "from mlcvs.cvs import DeepTICA\n",
     "\n",
     "# define CV\n",
-    "cv = DeepTICA(layers=[10,5,5,2], options={})\n",
+    "cv = DeepTICA(layers=[10, 5, 5, 2], options={})\n",
     "\n",
-    "# print default loss kwargs\n",
-    "print(f'default kwargs: {cv.loss_kwargs}')\n",
+    "# print default loss mode\n",
+    "print(f'default mode: {cv.loss_fn.mode}')\n",
     "\n",
-    "# change kwargs (we use update and not an assignment to avoid deleting the others)\n",
-    "cv.loss_kwargs.update( {'mode': 'sum'} ) \n",
+    "# change the mode\n",
+    "cv.loss_fn.mode = 'sum' \n",
     "\n",
-    "# print new loss kwargs\n",
-    "print(f'>> new  kwargs: {cv.loss_kwargs}')"
+    "# print new loss mode\n",
+    "print(f'>> new  mode: {cv.loss_fn.mode}')"
    ]
   },
   {

--- a/mlcvs/core/loss/tda_loss.py
+++ b/mlcvs/core/loss/tda_loss.py
@@ -52,6 +52,7 @@ class TDALoss(torch.nn.Module):
         beta : float, optional
             Sigmas loss compontent prefactor, by default 100.
         """
+        super().__init__()
         self.n_states = n_states
         self.target_centers = target_centers
         self.target_sigmas = target_sigmas

--- a/mlcvs/cvs/cv.py
+++ b/mlcvs/cvs/cv.py
@@ -35,9 +35,6 @@ class BaseCV:
         self._optimizer_name     = 'Adam'
         self.optimizer_kwargs    = {}
 
-        # LOSS
-        self.loss_kwargs         = {}
-
         # PRE/POST
         self.preprocessing      = preprocessing
         self.postprocessing     = postprocessing
@@ -54,7 +51,7 @@ class BaseCV:
     def parse_options(self, options : dict = None):
         """
         Sanitize options and create defaults ({}) if not in options.
-        Furthermore, sets loss and optimizer kwargs if given. 
+        Furthermore, it sets the optimizer kwargs, if given.
 
         Parameters
         ----------
@@ -69,12 +66,10 @@ class BaseCV:
 
         for o in options.keys():
             if o not in self.BLOCKS:
-                if o == 'loss':
-                    self.loss_kwargs.update(options[o])
-                elif o == 'optimizer':
+                if o == 'optimizer':
                     self.optimizer_kwargs.update(options[o])
                 else:
-                    raise ValueError(f'The key {o} is not available in this class. The available keys are: {",".join(self.BLOCKS)}, + (loss,optimizer) ')
+                    raise ValueError(f'The key {o} is not available in this class. The available keys are: {", ".join(self.BLOCKS)}, and optimizer.')
 
         return options
 

--- a/mlcvs/cvs/supervised/regression.py
+++ b/mlcvs/cvs/supervised/regression.py
@@ -66,6 +66,7 @@ class RegressionCV(BaseCV, pl.LightningModule):
         self.log(f'{name}_loss', loss, on_epoch=True)
         return loss
 
+
 def test_regression_cv():
     """
     Create a synthetic dataset and test functionality of the RegressionCV class
@@ -102,7 +103,7 @@ def test_regression_cv():
     print('weighted loss') 
     w = torch.randn((100))
     dataset_weights = DictionaryDataset({'data':X, 'target':y, 'weights':w})
-    datamodule_weights = DictionaryDataModule(dataset, lengths=[0.75,0.2,0.05], batch_size=25)
+    datamodule_weights = DictionaryDataModule(dataset_weights, lengths=[0.75,0.2,0.05], batch_size=25)
     trainer.fit(model, datamodule_weights)
         
     # use custom loss

--- a/mlcvs/cvs/unsupervised/vae.py
+++ b/mlcvs/cvs/unsupervised/vae.py
@@ -192,7 +192,7 @@ class VariationalAutoEncoderCV(BaseCV, pl.LightningModule):
             x_ref = x 
 
         # Loss function.
-        loss = self.loss_fn(x_ref, x_hat, mean, log_variance, **options)
+        loss = self.loss_fn(x_ref, x_hat, mean, log_variance, **loss_kwargs)
 
         # Log.
         name = 'train' if self.training else 'valid'       

--- a/mlcvs/cvs/unsupervised/vae.py
+++ b/mlcvs/cvs/unsupervised/vae.py
@@ -19,7 +19,7 @@ import torch
 import pytorch_lightning as pl
 from mlcvs.cvs import BaseCV
 from mlcvs.core import FeedForward, Normalization
-from mlcvs.core.loss import elbo_gaussians_loss
+from mlcvs.core.loss import ELBOGaussiansLoss
 
 
 # =============================================================================
@@ -73,9 +73,9 @@ class VariationalAutoEncoderCV(BaseCV, pl.LightningModule):
         """
         super().__init__(in_features=encoder_layers[0], out_features=n_cvs, **kwargs)
 
-        # =======   LOSS  ======= 
-        self.loss_fn     = elbo_gaussians_loss  #ELBO loss function when latent space and reconstruction distributions are Gaussians.      
-        self.loss_kwargs = {}                   # set default values before parsing options
+        # =======   LOSS  =======
+        #ELBO loss function when latent space and reconstruction distributions are Gaussians.
+        self.loss_fn = ELBOGaussiansLoss()
 
         # ======= OPTIONS ======= 
         # parse and sanitize
@@ -177,10 +177,10 @@ class VariationalAutoEncoderCV(BaseCV, pl.LightningModule):
 
     def training_step(self, train_batch, batch_idx):
         """Single training step performed by the PyTorch Lightning Trainer."""
-        options = self.loss_kwargs.copy()
         x = train_batch['data']
+        loss_kwargs = {}
         if 'weights' in train_batch:
-            options['weights'] = train_batch['weights']
+            loss_kwargs['weights'] = train_batch['weights']
 
         # Encode/decode.
         mean, log_variance, x_hat = self.encode_decode(x)


### PR DESCRIPTION
## Description
Changes the CV classes to use by default a loss function object.

It is still possible to assign ``loss_fn`` to a (lambda) function, although I had to override ``__setattr__`` to work around some weird PyTorch magic (hopefully the comments I left in the code makes it clear).

## Status
- [x] Ready to go