### PR TITLE
Multi-task CV and various fixes

### DIFF
--- a/mlcvs/core/loss/autocorrelation.py
+++ b/mlcvs/core/loss/autocorrelation.py
@@ -109,7 +109,7 @@ def autocorrelation_loss(
     if x_t.ndim == 2:
         if x_t.shape[1] > 1:
             raise ValueError('The autocorrelation loss should be used on (batches of) scalar '
-                             f'outputs, found tensor of shape {z_t.shape} instead.')
+                             f'outputs, found tensor of shape {x_t.shape} instead.')
         else:
             x_t = x_t.squeeze()
             x_lag = x_lag.squeeze()

--- a/mlcvs/core/loss/autocorrelation.py
+++ b/mlcvs/core/loss/autocorrelation.py
@@ -19,83 +19,110 @@ from typing import Optional
 
 import torch
 
+from mlcvs.core.stats.tica import TICA
+from mlcvs.core.loss.eigvals import reduce_eigenvalues_loss
+
 
 # =============================================================================
 # LOSS FUNCTIONS
 # =============================================================================
 
 class AutocorrelationLoss(torch.nn.Module):
-    r"""(Weighted) autocorrelation loss.
+    """(Weighted) autocorrelation loss.
 
-    .. math::
-
-        L = - \frac{\langle (x(t)-\bar{x}(t))(x(t+\tau)-\bar{x}(t)) \rangle}{\sigma(x_t)^2}
+    Computes the sum (or another reducing functions) of the eigenvalues of the
+    autocorrelation matrix. This is the same loss function used in
+    :class:`~mlcvs.cvs.timelagged.deeptica.DeepTICA`.
 
     """
 
-    def __init__(self, invert_sign: bool = True):
+    def __init__(self, reduce_mode: str = 'sum2', invert_sign: bool = True):
         """Constructor.
 
         Parameters
         ----------
+        reduce_mode : str
+            This determines how the eigenvalues are reduced, e.g., ``sum``, ``sum2``
+            (see also :class:`~mlcvs.core.loss.eigvals.ReduceEigenvaluesLoss`). The
+            default is ``'sum2'``.
         invert_sign: bool, optional
             Whether to return the negative autocorrelation in order to be minimized
             with gradient descent methods. Default is ``True``.
         """
         super().__init__()
+        self.reduce_mode = reduce_mode
         self.invert_sign = invert_sign
 
     def forward(
             self,
-            x_t: torch.Tensor,
+            x: torch.Tensor,
             x_lag: torch.Tensor,
             weights: Optional[torch.Tensor] = None,
+            weights_lag: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Estimate the autocorrelation.
 
         Parameters
         ----------
-        x_t : torch.Tensor
+        x : torch.Tensor
             Shape ``(n_batches, n_features)``. The features of the sample at
             time ``t``.
         x_lag : torch.Tensor
             Shape ``(n_batches, n_features)``. The features of the sample at
             time ``t + lag``.
         weights : torch.Tensor, optional
-            Shape ``(n_batches,)`` or ``(n_batches, 1)``. The weight associated
-            to each batch sample. Default is ``None``.
+            Shape ``(n_batches,)`` or ``(n_batches, 1)``. The weights associated
+            to ``x`` at time ``t``. Default is ``None``.
+        weights_lag : torch.Tensor, optional
+            Shape ``(n_batches,)`` or ``(n_batches, 1)``. The weights associated
+            to ``x`` at time ``t + lag``. Default is ``None``.
 
         Returns
         -------
         loss : torch.Tensor
             Loss value.
         """
-        return autocorrelation_loss(x_t, x_lag, weights=weights, invert_sign=self.invert_sign)
+        return autocorrelation_loss(
+            x, x_lag,
+            weights=weights,
+            weights_lag=weights_lag,
+            reduce_mode=self.reduce_mode,
+            invert_sign=self.invert_sign,
+        )
 
 
 def autocorrelation_loss(
-        x_t: torch.Tensor,
+        x: torch.Tensor,
         x_lag: torch.Tensor,
         weights: Optional[torch.Tensor] = None,
+        weights_lag: Optional[torch.Tensor] = None,
+        reduce_mode: str = 'sum2',
         invert_sign: bool = True,
 ) -> torch.Tensor:
-    r"""(Weighted) autocorrelation loss.
+    """(Weighted) autocorrelation loss.
 
-    .. math::
-
-        L = - \frac{\langle (x(t)-\bar{x}(t))(x(t+\tau)-\bar{x}(t)) \rangle}{\sigma(x_t)^2}
+    Computes the sum (or another reducing functions) of the eigenvalues of the
+    autocorrelation matrix. This is the same loss function used in
+    :class:`~mlcvs.cvs.timelagged.deeptica.DeepTICA`.
     
     Parameters
     ----------
-    x_t : torch.Tensor
+    x : torch.Tensor
         Shape ``(n_batches, n_features)``. The features of the sample at
         time ``t``.
     x_lag : torch.Tensor
         Shape ``(n_batches, n_features)``. The features of the sample at
         time ``t + lag``.
     weights : torch.Tensor, optional
-        Shape ``(n_batches,)`` or ``(n_batches, 1)``. The weight associated
-        to each batch sample. Default is ``None``.
+        Shape ``(n_batches,)`` or ``(n_batches, 1)``. The weights associated
+        to ``x`` at time ``t``. Default is ``None``.
+    weights_lag : torch.Tensor, optional
+        Shape ``(n_batches,)`` or ``(n_batches, 1)``. The weights associated
+        to ``x`` at time ``t + lag``. Default is ``None``.
+    reduce_mode : str
+        This determines how the eigenvalues are reduced, e.g., ``sum``, ``sum2``
+        (see also :class:`~mlcvs.core.loss.eigvals.ReduceEigenvaluesLoss`). The
+        default is ``'sum2'``.
     invert_sign: bool, optional
         Whether to return the negative autocorrelation in order to be minimized
         with gradient descent methods. Default is ``True``.
@@ -105,30 +132,7 @@ def autocorrelation_loss(
     loss: torch.Tensor
         Loss value.
     """
-    # Currently we support only 1 dimensional features.
-    if x_t.ndim == 2:
-        if x_t.shape[1] > 1:
-            raise ValueError('The autocorrelation loss should be used on (batches of) scalar '
-                             f'outputs, found tensor of shape {x_t.shape} instead.')
-        else:
-            x_t = x_t.squeeze()
-            x_lag = x_lag.squeeze()
-
-    if weights is None:
-        mean = x_t.mean()
-        std = x_t.std()
-        
-        loss = ((x_t-mean)*(x_lag-mean)).mean()/std**2
-    else:
-        weights = weights.squeeze()
-        weighted_mean = lambda x,w : (x*w).sum()/w.sum()
-
-        mean = weighted_mean(x_t, weights)
-        std = weighted_mean((x_t - mean)**2, weights).sqrt()
-        
-        loss = weighted_mean((x_t-mean)*(x_lag-mean), weights)/std**2
-    
-    if invert_sign:
-        return -loss
-
+    tica = TICA(in_features=x.shape[-1])
+    eigvals, _ = tica.compute(data=[x, x_lag], weights=[weights, weights_lag])
+    loss = reduce_eigenvalues_loss(eigvals, mode=reduce_mode, invert_sign=invert_sign)
     return loss

--- a/mlcvs/core/loss/fisher.py
+++ b/mlcvs/core/loss/fisher.py
@@ -57,6 +57,9 @@ class FisherDiscriminantLoss(torch.nn.Module):
             minimized with gradient descent methods. Default is ``True``.
         """
         super().__init__()
+        self.n_states = n_states
+        self.lda_mode = lda_mode
+        self.reduce_mode = reduce_mode
         self.invert_sign = invert_sign
 
     def forward(
@@ -78,7 +81,13 @@ class FisherDiscriminantLoss(torch.nn.Module):
         loss : torch.Tensor
             Loss value.
         """
-        return fisher_discriminant_loss(x, labels, self.invert_sign)
+        return fisher_discriminant_loss(
+            x, labels,
+            n_states=self.n_states,
+            lda_mode=self.lda_mode,
+            reduce_mode=self.reduce_mode,
+            invert_sign=self.invert_sign
+        )
 
 
 def fisher_discriminant_loss(

--- a/mlcvs/core/loss/fisher.py
+++ b/mlcvs/core/loss/fisher.py
@@ -53,7 +53,7 @@ class FisherDiscriminantLoss(torch.nn.Module):
         loss : torch.Tensor
             Loss value.
         """
-        return fisher_discriminant_loss(X, labels. self.invert_sign)
+        return fisher_discriminant_loss(X, labels, self.invert_sign)
 
 
 def fisher_discriminant_loss(

--- a/mlcvs/core/loss/fisher.py
+++ b/mlcvs/core/loss/fisher.py
@@ -17,6 +17,7 @@ __all__ = ['FisherDiscriminantLoss', 'fisher_discriminant_loss']
 
 import torch
 from mlcvs.core.stats import LDA
+from mlcvs.core.loss import reduce_eigenvalues_loss
 
 
 # =============================================================================
@@ -24,26 +25,50 @@ from mlcvs.core.stats import LDA
 # =============================================================================
 
 class FisherDiscriminantLoss(torch.nn.Module):
-    r""" Fisher's discriminant ratio.
+    """Fisher's discriminant ratio.
 
-    .. math::
-        L = - \frac{S_b(X)}{S_w(X)}
+    Computes the sum (or another reducing functions) of the eigenvalues of the
+    ratio between the Fisher's scatter matrices. This is the same loss function
+    used in :class:`~mlcvs.cvs.supervised.deeplda.DeepLDA`.
     """
 
-    def __init__(self, invert_sign : bool = True):
+    def __init__(
+            self,
+            n_states: int,
+            lda_mode: str = 'standard',
+            reduce_mode: str = 'sum',
+            invert_sign: bool = True):
+        """Constructor.
+
+        Parameters
+        ----------
+        n_states : int
+            The number of states. Labels are in the range ``[0, n_states-1]``.
+        lda_mode : str
+            Either ``'standard'`` or ``'harmonic'``. This determines how the scatter
+            matrices are computed (see also :class:`~mlcvs.core.stats.lda.LDA`). The
+            default is ``'standard'``.
+        reduce_mode : str
+            This determines how the eigenvalues are reduced, e.g., ``sum``, ``sum2``
+            (see also :class:`~mlcvs.core.loss.eigvals.ReduceEigenvaluesLoss`). The
+            default is ``'sum'``.
+        invert_sign: bool, optional
+            Whether to return the negative Fisher's discriminant ratio in order to be
+            minimized with gradient descent methods. Default is ``True``.
+        """
         super().__init__()
         self.invert_sign = invert_sign
 
     def forward(
             self,
-            X: torch.Tensor,
+            x: torch.Tensor,
             labels: torch.Tensor,
     ) -> torch.Tensor:
         """Compute the value of the loss function.
 
         Parameters
         ----------
-        X : torch.Tensor
+        x : torch.Tensor
             Shape ``(n_batches, n_features)``. Input features.
         labels : torch.Tensor
             Shape ``(n_batches,)``. Classes labels.
@@ -53,28 +78,41 @@ class FisherDiscriminantLoss(torch.nn.Module):
         loss : torch.Tensor
             Loss value.
         """
-        return fisher_discriminant_loss(X, labels, self.invert_sign)
+        return fisher_discriminant_loss(x, labels, self.invert_sign)
 
 
 def fisher_discriminant_loss(
-        X: torch.Tensor,
+        x: torch.Tensor,
         labels: torch.Tensor,
-        invert_sign: bool = True
+        n_states: int,
+        lda_mode: str = 'standard',
+        reduce_mode: str = 'sum',
+        invert_sign: bool = True,
 ) -> torch.Tensor:
-    r""" Fisher's discriminant ratio.
+    """Fisher's discriminant ratio.
 
-    .. math::
-
-        L = - \frac{S_b(X)}{S_w(X)}
+    Computes the sum (or another reducing functions) of the eigenvalues of the
+    ratio between the Fisher's scatter matrices. This is the same loss function
+    used in :class:`~mlcvs.cvs.supervised.deeplda.DeepLDA`.
     
     Parameters
     ----------
-    X : torch.Tensor
+    x : torch.Tensor
         Shape ``(n_batches, n_features)``. Input features.
     labels : torch.Tensor
         Shape ``(n_batches,)``. Classes labels.
+    n_states : int
+        The number of states. Labels are in the range ``[0, n_states-1]``.
+    lda_mode : str
+        Either ``'standard'`` or ``'harmonic'``. This determines how the scatter
+        matrices are computed (see also :class:`~mlcvs.core.stats.lda.LDA`). The
+        default is ``'standard'``.
+    reduce_mode : str
+        This determines how the eigenvalues are reduced, e.g., ``sum``, ``sum2``
+        (see also :class:`~mlcvs.core.loss.eigvals.ReduceEigenvaluesLoss`). The
+        default is ``'sum'``.
     invert_sign: bool, optional
-        whether to return the negative Fisher's discriminant ratio in order to be
+        Whether to return the negative Fisher's discriminant ratio in order to be
         minimized with gradient descent methods. Default is ``True``.
 
     Returns
@@ -82,24 +120,7 @@ def fisher_discriminant_loss(
     loss: torch.Tensor
         Loss value.
     """
-
-    if X.ndim == 1:
-        X = X.unsqueeze(1) # for lda compute_scatter_matrices method
-    if X.ndim == 2 and X.shape[1] > 1:
-        raise ValueError (f'fisher_discriminant_loss should be used on (batches of) scalar outputs, found tensor of shape {X.shape} instead.')
-
-    # get params
-    d = X.shape[-1] if X.ndim == 2 else 1
-    n_classes = len(labels.unique())
-
-    # define LDA object to compute S_b / S_w ratio
-    lda = LDA(in_features=d, n_states=n_classes)
-
-    s_b, s_w = lda.compute_scatter_matrices(X,labels)
-
-    loss = s_b.squeeze() / s_w.squeeze()
-
-    if invert_sign:
-        loss *= -1
-
+    lda = LDA(in_features=x.shape[-1], n_states=n_states, mode=lda_mode)
+    eigvals, _ = lda.compute(x, labels)
+    loss = reduce_eigenvalues_loss(eigvals, mode=reduce_mode, invert_sign=invert_sign)
     return loss

--- a/mlcvs/core/loss/tda_loss.py
+++ b/mlcvs/core/loss/tda_loss.py
@@ -63,6 +63,7 @@ class TDALoss(torch.nn.Module):
             self,
             H: torch.Tensor,
             labels: torch.Tensor,
+            return_loss_terms: bool = False
     ) -> torch.Tensor:
         """Compute the value of the loss function.
 
@@ -72,13 +73,24 @@ class TDALoss(torch.nn.Module):
             Shape ``(n_batches, n_features)``. Output of the NN.
         labels : torch.Tensor
             Shape ``(n_batches,)``. Labels of the dataset.
+        return_loss_terms : bool, optional
+            If ``True``, the loss terms associated to the center and standard
+            deviations of the target Gaussians are returned as well. Default
+            is ``False``.
 
         Returns
         -------
         loss : torch.Tensor
             Loss value.
+        loss_centers : torch.Tensor, optional
+            Only returned if ``return_loss_terms is True``. The value of the
+            loss term associated to the centers of the target Gaussians.
+        loss_sigmas : torch.Tensor, optional
+            Only returned if ``return_loss_terms is True``. The value of the
+            loss term associated to the standard deviations of the target Gaussians.
         """
-        return tda_loss(H, labels, self.n_states, self.target_centers, self.target_sigmas, self.alfa, self.beta)
+        return tda_loss(H, labels, self.n_states, self.target_centers, self.target_sigmas,
+                        self.alfa, self.beta, return_loss_terms)
 
 
 def tda_loss(
@@ -89,6 +101,7 @@ def tda_loss(
         target_sigmas: Union[list, torch.Tensor],
         alfa: float = 1,
         beta: float = 100,
+        return_loss_terms: bool = False
 ) -> torch.Tensor:
     """
     Compute a loss function as the distance from a simple Gaussian target distribution.
@@ -109,11 +122,20 @@ def tda_loss(
         Centers_loss component prefactor, by default 1.
     beta : float, optional
         Sigmas loss compontent prefactor, by default 100.
+    return_loss_terms : bool, optional
+        If ``True``, the loss terms associated to the center and standard deviations
+        of the target Gaussians are returned as well. Default is ``False``.
 
     Returns
     -------
-    torch.Tensor
-        Total loss, centers loss, and sigmas loss.
+    loss : torch.Tensor
+        Loss value.
+    loss_centers : torch.Tensor, optional
+        Only returned if ``return_loss_terms is True``. The value of the loss
+        term associated to the centers of the target Gaussians.
+    loss_sigmas : torch.Tensor, optional
+        Only returned if ``return_loss_terms is True``. The value of the loss
+        term associated to the standard deviations of the target Gaussians.
     """
     if not isinstance(target_centers, torch.Tensor):
         target_centers = torch.Tensor(target_centers)
@@ -146,4 +168,6 @@ def tda_loss(
     loss_sigmas = torch.sum(loss_sigmas) 
     loss = loss_centers + loss_sigmas  
 
-    return loss, loss_centers, loss_sigmas
+    if return_loss_terms:
+        return loss, loss_centers, loss_sigmas
+    return loss

--- a/mlcvs/core/nn/feedforward.py
+++ b/mlcvs/core/nn/feedforward.py
@@ -1,49 +1,87 @@
-import torch 
-import pytorch_lightning as pl
-from mlcvs.core.nn.utils import get_activation, parse_nn_options
+#!/usr/bin/env python
+
+# =============================================================================
+# MODULE DOCSTRING
+# =============================================================================
+
+"""
+Variational Autoencoder collective variable.
+"""
 
 __all__ = ["FeedForward"]
 
+
+# =============================================================================
+# GLOBAL IMPORTS
+# =============================================================================
+
+from typing import Optional, Union
+
+import torch
+import pytorch_lightning as pl
+from mlcvs.core.nn.utils import get_activation, parse_nn_options
+
+
+# =============================================================================
+# STANDARD FEED FORWARD
+# =============================================================================
+
 class FeedForward(pl.LightningModule):
+    """Define a feedforward neural network given the list of layers.
 
-    def __init__(self, 
-                layers : list, 
-                activation: str or list = "relu", 
-                dropout: int or list = None, 
-                batchnorm: str or list = None, 
-                **kwargs 
+    Optionally dropout and batchnorm can be applied (the order is activation -> dropout -> batchnorm).
+    """
+
+    def __init__(
+            self,
+            layers : list,
+            activation: Union[str, list] = "relu",
+            dropout: Optional[Union[float, list]] = None,
+            batchnorm: Union[bool, list] = False,
+            last_layer_activation: bool = False,
+            **kwargs
     ):
-        """
-        Define a feedforward neural network given the list of layers.
-
-        Optionally dropout and batchnorm can be applied (the order is activation -> dropout -> batchnorm).
+        """Constructor.
 
         Parameters
         ----------
         layers : list
-            Number of neurons per layer
-        activation : string or list of strings (activation per each layer)
-            Activation function (options: relu, tanh, elu, linear)
-        dropout : float or list of floats (dropout per each layer)
-            Dropout after each layer
-        batchnorm : bool or list of booleans (batchnorm per each layer)
-            Batchnorm after each layer
+            Number of neurons per layer.
+        activation : string or list[str], optional
+            Add activation function (options: relu, tanh, elu, linear). If a
+            ``list``, this must have length ``len(layers)-1``, and ``activation[i]``
+            controls whether to add the activation to the ``i``-layer.
+        dropout : float or list[float], optional
+            Add dropout with this probability after each layer. If a ``list``,
+            this must have length ``len(layers)-1``, and ``dropout[i]`` specifies
+            the the dropout probability for the ``i``-th layer.
+        batchnorm : bool or list[bool], optional
+            Add batchnorm after each layer. If a ``list``, this must have
+            length ``len(layers)-1``, and ``batchnorm[i]`` controls whether to
+            add the batchnorm to the ``i``-th layer.
+        last_layer_activation : bool, optional
+            If ``True`` and activation, dropout, and batchnorm are added also to
+            the output layer when ``activation``, ``dropout``, or ``batchnorm``
+            (i.e., they are not lists). Otherwise, the output layer will be linear.
+            This option is ignored for the arguments among ``activation``, ``dropout``,
+            and ``batchnorm`` that are passed as lists.
         **kwargs:
-            Optional arguments passed to torch.nn.module
+            Optional arguments passed to torch.nn.Module
         """
         super().__init__(**kwargs)
 
         # Parse layers
-        if not isinstance(layers[0],int):
+        if not isinstance(layers[0], int):
             raise TypeError('layers should be a list-type of integers.')
         
         # Parse options per each hidden layer
+        n_layers = len(layers) - 1
         # -- activation
-        activation_list = parse_nn_options(activation,  len(layers)-1)
+        activation_list = parse_nn_options(activation, n_layers, last_layer_activation)
         # -- dropout
-        dropout_list    = parse_nn_options(dropout,     len(layers)-1)
+        dropout_list = parse_nn_options(dropout, n_layers, last_layer_activation)
         # -- batchnorm
-        batchnorm_list  = parse_nn_options(batchnorm,   len(layers)-1)
+        batchnorm_list = parse_nn_options(batchnorm, n_layers, last_layer_activation)
         
         # Create network
         modules = []
@@ -61,36 +99,13 @@ class FeedForward(pl.LightningModule):
                 modules.append(torch.nn.BatchNorm1d(layers[i+1]))
 
         # store model and attributes
-        self.nn     = torch.nn.Sequential(*modules)
-        self.in_features   = layers[0]
-        self.out_features  = layers[-1]
+        self.nn = torch.nn.Sequential(*modules)
+        self.in_features = layers[0]
+        self.out_features = layers[-1]
 
     #def extra_repr(self) -> str:
     #    repr = f"in_features={self.in_features}, out_features={self.out_features}"
     #    return repr
 
-    def forward(self, x: torch.Tensor) -> (torch.Tensor):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.nn(x)
-
-def test_feedforward():
-    torch.manual_seed(42)
-    
-    in_features = 2
-    layers = [2,10,10,1]
-    model = FeedForward(layers,activation='relu')
-    print(model)
-
-    X = torch.zeros(in_features)
-    print(model(X))
-
-    # custom options per layers
-    activ   = ['relu','tanh',None]
-    dropout = 0.5
-    batchnorm = True
-
-    model = FeedForward(layers, activation=activ, dropout=dropout, batchnorm=batchnorm)
-    print(model)
-
-
-if __name__ == "__main__":
-    test_feedforward()

--- a/mlcvs/core/nn/utils.py
+++ b/mlcvs/core/nn/utils.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn.functional as F
 import math
 
+
 class Shifted_Softplus(torch.nn.Softplus):
     """Element-wise softplus function shifted as to pass from the origin."""
     
@@ -11,6 +12,7 @@ class Shifted_Softplus(torch.nn.Softplus):
     def forward(self, input):
         sp0 = F.softplus(torch.zeros(1), self.beta, self.threshold).item()
         return F.softplus(input, self.beta, self.threshold) - sp0
+
 
 def get_activation(activation : str):
     """ Return activation module given string. """
@@ -35,17 +37,25 @@ def get_activation(activation : str):
         )
     return activ
 
-def parse_nn_options( options : str, n_layers : int ):
-    """Parse args per layer of the NN. If a single value is given, repeat options to all layers but for the output one"""
+
+def parse_nn_options(options: str, n_layers: int, last_layer_activation: bool):
+    """Parse args per layer of the NN.
+
+    If a single value is given, repeat options to all layers but for the output one,
+    unless ``last_layer_activation is True``, in which case the option is repeated
+    also for the output layer.
+    """
     # If an iterable is given cheeck that its length matches the number of NN layers
     if hasattr(options, '__iter__') and not isinstance(options, str):
         if len(options) != n_layers:
             raise ValueError(f'Length of options: {options} ({len(options)} should be equal to number of layers ({n_layers})).')
         options_list = options
     # if a single value is given, repeat options to all layers but for the output one
-    else: 
-        options_list = [ options for _ in range(n_layers-1) ]
-        options_list.append(None)
+    else:
+        if last_layer_activation:
+            options_list = [options for _ in range(n_layers)]
+        else:
+            options_list = [options for _ in range(n_layers-1)]
+            options_list.append(None)
     
     return options_list
-

--- a/mlcvs/core/stats/utils.py
+++ b/mlcvs/core/stats/utils.py
@@ -38,11 +38,9 @@ def cholesky_eigh(A, B, reg_B = 1e-6, n_eig = None ):
     eigvecs = torch.matmul(L_ti, eigvecs)
 
     # (5) normalize them
-    for i in range(eigvecs.shape[1]): 
-        norm = eigvecs[:, i].pow(2).sum().sqrt()
-        eigvecs[:, i].div_(norm)
+    eigvecs = torch.nn.functional.normalize(eigvecs, dim=0)
     # set the first component positive
-    eigvecs.mul_(torch.sign(eigvecs[0, :]).unsqueeze(0).expand_as(eigvecs))
+    eigvecs = eigvecs.mul(torch.sign(eigvecs[0, :]).unsqueeze(0).expand_as(eigvecs))
 
     # (6) keep only first n_eig eigvals and eigvecs
     if n_eig is not None:

--- a/mlcvs/core/transform/normalization.py
+++ b/mlcvs/core/transform/normalization.py
@@ -126,7 +126,13 @@ class Normalization(Transform):
     def setup_from_datamodule(self,datamodule):
         if not self.is_initialized:
             # obtain statistics from the dataloader
-            stats = datamodule.train_dataloader().get_stats()['data']
+            try:
+                stats = datamodule.train_dataloader().get_stats()['data']
+            except KeyError:
+                raise ValueError(f'Impossible to initialize {self.__class__.__name__} '
+                                 'because the training dataloader does not have a "data" key '
+                                 '(are you using multiple datasets?). A manual initialization '
+                                 'of "mean" and "range" is necessary.')
             self.set_from_stats(stats,self.mode)
 
     def forward(self, x: torch.Tensor) -> (torch.Tensor):

--- a/mlcvs/cvs/multitask/__init__.py
+++ b/mlcvs/cvs/multitask/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ['MultiTaskCV']
+
+from mlcvs.cvs.multitask.multitask import *

--- a/mlcvs/cvs/multitask/multitask.py
+++ b/mlcvs/cvs/multitask/multitask.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+
+# =============================================================================
+# MODULE DOCSTRING
+# =============================================================================
+
+"""
+Classes and utilities for multi-task collective variable.
+"""
+
+__all__ = ["MultiTaskCV"]
+
+# =============================================================================
+# GLOBAL IMPORTS
+# =============================================================================
+
+from typing import Optional, Sequence
+
+import torch
+
+from mlcvs.cvs.cv import BaseCV
+
+
+# =============================================================================
+# VARIATIONAL AUTOENCODER CV
+# =============================================================================
+
+class MultiTaskCV:
+    """Multi-task collective variable.
+
+    This class wraps an existing CV object and adds a linear combination of other
+    auxiliary loss functions that target different datasets with different information.
+    The class works only if the ``main_cv`` does not make use of ``__slots__``.
+
+    Examples
+    --------
+
+    A semi-supervised autoencoder mixing ELBO and the Fisher's discriminant loss.
+
+    >>> from mlcvs.cvs import AutoEncoderCV
+    >>> from mlcvs.core.loss import FisherDiscriminantLoss
+    >>> from mlcvs.data import DictionaryDataset, DictionaryDataModule
+
+    >>> n_descriptors = 5
+    >>> n_labels = 2  # Number of states
+    >>> n_cvs = 2
+
+    Initialize the multi-task CV. The Fisher's discriminant loss has half the
+    weight of the ELBO loss.
+
+    >>> main_cv = AutoEncoderCV(encoder_layers=[n_descriptors, 10, n_cvs])
+    >>> aux_loss_fn = FisherDiscriminantLoss(n_states=n_labels)
+    >>> multi_cv = MultiTaskCV(main_cv, auxiliary_loss_fns=[aux_loss_fn], loss_coefficients=[0.5])
+
+    MultiTaskCV now exposes the same API as AutoEncoderCV.
+
+    >>> multi_cv.norm_in.set_custom(mean=torch.tensor(0.0), range=torch.tensor(1.0))
+
+    Create a multi-dataset datamodule for this CV.
+
+    >>> n_samples = 100
+    >>> unsupervised_dataset = DictionaryDataset({
+    ...     'data': torch.rand(n_samples, n_descriptors),
+    ... })
+    >>> supervised_dataset = DictionaryDataset({
+    ...     'data': torch.rand(n_samples, n_descriptors),
+    ...     'labels': torch.tensor([0., 1]).repeat(n_samples//2)
+    ... })
+    >>> datamodule = DictionaryDataModule(dataset=[unsupervised_dataset, supervised_dataset])
+
+    # Create a PyTorch Lightning trainer.
+    >>> import pytorch_lightning as pl
+    >>> trainer = pl.Trainer(max_epochs=1, log_every_n_steps=5, logger=None, enable_checkpointing=False)
+
+    """
+    
+    def __init__(
+            self,
+            main_cv: BaseCV,
+            auxiliary_loss_fns: Sequence,
+            loss_coefficients : Optional[Sequence[float]] = None
+    ):
+        """
+        Constructor.
+
+        Parameters
+        ----------
+        main_cv : BaseCV
+            The main collective variable. The CV will dynamically inherit from
+            this object's class and expose all its members.
+        auxiliary_loss_fns : list
+            A list of auxiliary loss functions.
+        loss_coefficients : list-like of floats, optional
+            A list of length ``len(auxiliary_loss_fns)`` with the coefficients
+            of the linear combination of loss functions. If not provided, all
+            auxiliary loss functions are assigned coefficient 1 (the main CV
+            has always coefficient 1).
+
+        """
+        # This changes dynamically the class of this object to inherit both from
+        # MultiTaskCV and main_cv.__class__ so that we can access all members of
+        # main_cv and still be able to override some of them.
+        self.__class__ = type(
+            'MultiTask'+main_cv.__class__.__name__,  # class name
+            (self.__class__, main_cv.__class__),  # base classes
+            {}  # self.__class__.__dict__
+        )
+
+        # Copy all members of main_cv into this object.
+        self.__dict__ = main_cv.__dict__
+
+        self.auxiliary_loss_fns = auxiliary_loss_fns
+        self.loss_coefficients = loss_coefficients
+
+    def training_step(self, train_batch, batch_idx):
+        stage = 'train' if self.training else 'valid'
+
+        # Compute main loss (the main CV should already log the first loss).
+        loss = super().training_step(train_batch['dataset0'], batch_idx)
+
+        # Compute auxiliary losses one by one.
+        for loss_idx, aux_loss_fn in enumerate(self.auxiliary_loss_fns):
+            dataset_batch = train_batch['dataset' + str(loss_idx+1)]
+
+            # Prepare keyword arguments to pass to the auxiliary loss function.
+            aux_loss_kwargs = {k: v for k, v in dataset_batch.items() if not k.startswith('data')}
+
+            # Forward data of this dataset (and eventually the time-lagged one).
+            cv = self.forward_cv(dataset_batch['data'])
+            try:
+                cv_lag = self.forward_cv(dataset_batch['data_lag'])
+            except KeyError:  # Not a time-lagged CV.
+                aux_loss = aux_loss_fn(cv, **aux_loss_kwargs)
+            else:
+                aux_loss = aux_loss_fn(cv, cv_lag, **aux_loss_kwargs)
+
+            # Log the auxiliary loss (before the coefficient).
+            self.log(f'{stage}_aux_loss_{loss_idx}', aux_loss.to(float), on_epoch=True)
+
+            if self.loss_coefficients is not None:
+                aux_loss = self.loss_coefficients[loss_idx] * aux_loss
+            loss = loss + aux_loss
+
+        # Log the total loss
+        self.log(f'{stage}_total_loss', loss.to(float), on_epoch=True)
+
+        # return loss
+        return loss
+
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()

--- a/mlcvs/cvs/supervised/deeptda.py
+++ b/mlcvs/cvs/supervised/deeptda.py
@@ -94,7 +94,7 @@ class DeepTDA(BaseCV, pl.LightningModule):
         # =================forward====================
         z = self.forward_cv(x)
         # ===================loss=====================
-        loss, loss_centers, loss_sigmas = self.loss_fn(z, labels)
+        loss, loss_centers, loss_sigmas = self.loss_fn(z, labels, return_loss_terms=True)
         # ====================log=====================+
         name = 'train' if self.training else 'valid'
         self.log(f'{name}_loss', loss.to(float), on_epoch=True)

--- a/mlcvs/tests/test_core_model_feedforward.py
+++ b/mlcvs/tests/test_core_model_feedforward.py
@@ -1,7 +1,0 @@
-import pytest
-
-from mlcvs.core.nn.feedforward import test_feedforward
-
-if __name__ == "__main__":
-    test_feedforward()
-

--- a/mlcvs/tests/test_core_nn_feedforward.py
+++ b/mlcvs/tests/test_core_nn_feedforward.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+
+
+# =============================================================================
+# MODULE DOCSTRING
+# =============================================================================
+
+"""
+Test objects and function in mlcvs.core.nn.feedforward.
+"""
+
+
+# =============================================================================
+# GLOBAL IMPORTS
+# =============================================================================
+
+import pytest
+import torch
+
+from mlcvs.core.nn.feedforward import FeedForward
+
+
+# =============================================================================
+# TESTS
+# =============================================================================
+
+@pytest.mark.parametrize('activation', [
+    'relu',
+    ['relu', 'tanh', None],
+    ['relu', 'tanh', 'relu'],
+])
+@pytest.mark.parametrize('dropout', [
+    None,
+    0.5,
+    [0.2, 0.3, None],
+    [0.2, 0.3, 0.4],
+])
+@pytest.mark.parametrize('batchnorm', [
+    False,
+    True,
+    [True, True, False],
+    [True, False, True],
+])
+@pytest.mark.parametrize('last_layer_activation', [False, True])
+def test_feedforward(activation, dropout, batchnorm, last_layer_activation):
+    """The model is constructed with the correct layers."""
+    in_features = 2
+    layers = [in_features, 10, 10, 1]
+    max_n_activ_layers = len(layers) - 1
+
+    # Create model.
+    model = FeedForward(
+        layers=layers,
+        activation=activation,
+        dropout=dropout,
+        batchnorm=batchnorm,
+        last_layer_activation=last_layer_activation
+    )
+
+    # Check batchnorm.
+    if isinstance(batchnorm, list):
+        n_batchnorm = sum(batchnorm)
+    elif last_layer_activation:
+        n_batchnorm = int(batchnorm) * max_n_activ_layers
+    else:
+        n_batchnorm = int(batchnorm) * (max_n_activ_layers-1)
+    assert sum(isinstance(l, torch.nn.BatchNorm1d) for l in model.nn) == n_batchnorm
+
+    # Check dropout.
+    if isinstance(dropout, list):
+        n_dropout = sum(d is not None for d in dropout)
+    elif last_layer_activation:
+        n_dropout = int(dropout is not None) * max_n_activ_layers
+    else:
+        n_dropout = int(dropout is not None) * (max_n_activ_layers-1)
+    assert sum(isinstance(l, torch.nn.Dropout) for l in model.nn) == n_dropout
+
+    # Check activation.
+    if isinstance(activation, list):
+        n_activations = sum(a is not None for a in activation)
+    elif last_layer_activation:
+        n_activations = int(activation is not None) * max_n_activ_layers
+    else:
+        n_activations = int(activation is not None) * (max_n_activ_layers-1)
+    n_linear = len(layers) - 1
+    assert len(model.nn) == n_linear + n_activations + n_dropout + n_batchnorm
+
+    # Test that the forward doesn't explode.
+    batch_size = 2
+    x = torch.zeros((batch_size, in_features))
+    model(x)

--- a/mlcvs/tests/test_cvs_multitask_multitask.py
+++ b/mlcvs/tests/test_cvs_multitask_multitask.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python
+
+
+# =============================================================================
+# MODULE DOCSTRING
+# =============================================================================
+
+"""
+Test objects and functions in mlcvs.cvs.multitask.multitask.
+"""
+
+
+# =============================================================================
+# GLOBAL IMPORTS
+# =============================================================================
+
+import tempfile
+
+import pytest
+import pytorch_lightning as pl
+import torch
+
+from mlcvs.core.loss import TDALoss, FisherDiscriminantLoss, AutocorrelationLoss
+from mlcvs.cvs.cv import BaseCV
+from mlcvs.cvs.multitask.multitask import MultiTaskCV
+from mlcvs.cvs.timelagged import DeepTICA
+from mlcvs.cvs.unsupervised import AutoEncoderCV, VariationalAutoEncoderCV
+from mlcvs.data import DictionaryDataset, DictionaryDataModule
+
+
+# =============================================================================
+# GLOBAL VARIABLES
+# =============================================================================
+
+N_DESCRIPTORS = 4
+N_CVS = 2
+N_STATES = 3
+
+
+# =============================================================================
+# TEST UTILITY FUNCTIONS/CLASSES
+# =============================================================================
+
+class MockAuxLoss(torch.nn.Module):
+    """Mock auxiliary loss for mock testing."""
+
+    def __init__(self):
+        super().__init__()
+        self.n_called = 0
+        self.args = None
+        self.kwargs = None
+
+    def forward(self, data, data_lag=None, **kwargs):
+        self.kwargs = kwargs
+        self.n_called += 1
+        return torch.tensor(1.)
+
+
+class MockCV(BaseCV, pl.LightningModule):
+    """Mock CV for mock testing."""
+
+    BLOCKS = []
+
+    def __init__(self, in_features=N_DESCRIPTORS, out_features=N_CVS):
+        """Constructor."""
+        super().__init__(in_features=in_features, out_features=out_features)
+        self.loss_fn = MockAuxLoss()
+        # This module is here to avoid optimizer(model.parameters()) exploding.
+        self.nn = torch.nn.Linear(in_features, out_features)
+
+    def training_step(self, train_batch, batch_idx):
+        """Training step."""
+        return self.loss_fn(**train_batch)
+
+
+def create_dataset(
+        dataset_type,
+        weights=False,
+        n_samples=40,
+        n_descriptors=N_DESCRIPTORS,
+        n_labels=N_STATES
+):
+    """Create one of three types of datasets with random data for testing.
+
+    dataset_type can be 'unsupervised', 'supervised', or 'time-lagged', which will
+    determine the fields of the dataset:
+
+    * 'unsupervised': 'data', ('weights')
+    * 'supervised': 'data', 'labels', ('weights')
+    * 'time-lagged': 'data', 'data_lag', ('weights', 'weights_lag')
+
+    Weights are added only if ``weights`` is ``True``.
+
+    """
+    assert dataset_type in set(['supervised', 'unsupervised', 'time-lagged'])
+
+    data = {'data': torch.randn((n_samples, n_descriptors))}
+
+    # Add weights.
+    if weights:
+        data['weights'] = torch.rand(n_samples)
+
+    # Data-type-specific fields.
+    if dataset_type == 'supervised':
+        # With sequential sampling, this make sure that all labels are represented
+        # in the validation and training set so that LDA/TDA don't complain.
+        labels = torch.arange(n_labels, dtype=torch.get_default_dtype())
+        data['labels'] = labels.repeat(n_samples//n_labels+1)[:n_samples]
+    elif dataset_type == 'time-lagged':
+        data['data_lag'] = torch.randn((n_samples, n_descriptors))
+        if weights:
+            data['weights_lag'] = torch.rand(n_samples)
+
+    return DictionaryDataset(data)
+
+
+def create_cv(cv_name, n_descriptors=N_DESCRIPTORS, n_cvs=N_CVS):
+    """Return a new CV and its associated dataset type (see create_dataset).
+
+    cv_name can be one of 'ae', 'vae', or 'deeptica'.
+    """
+    if cv_name == 'ae':
+        returned = 'unsupervised', AutoEncoderCV(encoder_layers=[n_descriptors, 10, n_cvs])
+    elif cv_name == 'vae':
+        returned = 'unsupervised', VariationalAutoEncoderCV(n_cvs=n_cvs, encoder_layers=[n_descriptors, 10])
+    elif cv_name == 'deeptica':
+        returned = 'time-lagged', DeepTICA(layers=[n_descriptors, 10, n_cvs])
+    else:
+        raise ValueError('Unrecognized cv_name.')
+
+    # With multiple dataset, Normalization's parameters must be initialized manually.
+    # This work because by default mean and range are assigned 0 and 1 value.
+    returned[1].norm_in.is_initialized = True
+
+    return returned
+
+
+def create_loss(loss_name, n_states=N_STATES, n_cvs=N_CVS):
+    """Return a loss and its associated dataset type (see create_dataset).
+
+    loss_name can be one of 'lda', 'tda', and 'autocorrelation' or a list of these
+    elements.
+
+    """
+    if loss_name == 'autocorrelation':
+        return 'time-lagged', AutocorrelationLoss()
+    elif loss_name == 'lda':
+        return 'supervised', FisherDiscriminantLoss(n_states=n_states)
+    elif loss_name == 'tda':
+        cv = TDALoss(
+            n_states=N_STATES,
+            target_centers=torch.linspace(-1, 1, N_STATES).unsqueeze(-1).repeat(1, N_CVS),
+            target_sigmas=torch.tensor([0.2]*N_STATES).unsqueeze(-1).repeat(1, N_CVS)
+        )
+        return 'supervised', cv
+    else:
+        raise ValueError('Unrecognized loss_name')
+
+
+def create_multitask_cv_and_datasets(main_cv_name, weights, auxiliary_loss_names, loss_coefficients):
+    """Return a new MultiTaskCV object and a list of compatible datasets.
+
+    main_cv_name can take all values supported in create_cv().
+    weights are passed to create_dataset()
+    auxiliary_loss_names can take all values supported in create_loss().
+    loss_coefficients are passed directly to MultiTaskCV.__init__().
+
+    Return the MultiTaskCV object and a list of datasets.
+
+    """
+    # Instantiate the base CV model and its dataset.
+    dataset_type, main_cv = create_cv(main_cv_name)
+    datasets = [create_dataset(dataset_type, weights=weights)]
+
+    # Instantiate the auxiliary losses and its datasets.
+    aux_losses = []
+    for aux_loss_name in auxiliary_loss_names:
+        dataset_type, loss = create_loss(aux_loss_name)
+        aux_losses.append(loss)
+        datasets.append(create_dataset(dataset_type))
+
+    # Create the MultiTask CV.
+    multi_cv = MultiTaskCV(main_cv, aux_losses, loss_coefficients)
+
+    return multi_cv, datasets
+
+
+# =============================================================================
+# TESTS
+# =============================================================================
+
+@pytest.mark.parametrize('dataset_types,weights,loss_coefficients', [
+    (['supervised', 'unsupervised'], [False, False], None),
+    (['unsupervised', 'supervised', 'time-lagged'], [True, False, True], None),
+    (['time-lagged', 'unsupervised', 'supervised'], [True, True, True], [2., 5.]),
+])
+def test_multitask_loss(dataset_types, weights, loss_coefficients):
+    """Auxiliary loss functions are called correctly."""
+    # Create mock MultitaskCV.
+    main_cv = MockCV()
+    aux_loss_fns = [MockAuxLoss() for _ in range(len(dataset_types)-1)]
+    datasets = [create_dataset(dt, weights=w) for dt, w in zip(dataset_types, weights)]
+    multi_cv = MultiTaskCV(main_cv, aux_loss_fns, loss_coefficients)
+
+    # Do two steps of training.
+    datamodule = DictionaryDataModule(datasets, shuffle=False, random_split=False)
+    trainer = pl.Trainer(max_epochs=1, log_every_n_steps=5, logger=None, enable_checkpointing=False)
+
+    # This will explode during backpropagation because the MockAuxLoss do not depend
+    # on the input. We don't care as long as MockAuxLoss.forward() is called.
+    try:
+        trainer.fit(multi_cv, datamodule)
+    except RuntimeError:
+        pass
+
+    # Check that all mock loss functions have been called twice.
+    all_losses = [multi_cv.loss_fn] + multi_cv.auxiliary_loss_fns
+    assert all([loss.n_called > 0 for loss in all_losses])
+
+    # Check that all fields were passed.
+    for loss, dataset, dataset_type, weighted in zip(all_losses, datasets, dataset_types, weights):
+        if dataset_type == 'supervised':
+            expected_kwargs = {'labels'}
+        else:
+            expected_kwargs = set()
+        if weighted:
+            expected_kwargs.add('weights')
+            if dataset_type == 'time-lagged':
+                expected_kwargs.add('weights_lag')
+        assert set(loss.kwargs.keys()) == expected_kwargs
+
+    # Hack to deactivate logging since calling training_step without a trainer explodes because of it.
+    def _log(name, value, on_epoch):
+        pass
+    multi_cv.log = _log
+
+    # Check value of the expected loss
+    if loss_coefficients is None:
+        expected_loss = float(len(all_losses))
+    else:
+        expected_loss = 1 + sum(loss_coefficients)
+    batch = {f'dataset{i}': datasets[i][:1] for i in range(len(datasets))}
+    loss = multi_cv.training_step(batch, None)
+    assert torch.allclose(loss, torch.tensor(expected_loss))
+
+
+@pytest.mark.parametrize('main_cv_name,weights', [
+    ('ae', False),
+    ('ae', True),
+    ('vae', False),
+    ('vae', True),
+    ('deeptica', True),  # DeepTICA currently doesn't support unweighted data.
+])
+@pytest.mark.parametrize('auxiliary_loss_names,loss_coefficients', [
+    (['tda'], None),
+    (['lda'], None),
+    (['autocorrelation'], None),  # This ends up testing DeepTICA + autocorrelation. Doesn't make sense but we can do it.
+    (['lda', 'autocorrelation'], None),
+    (['tda', 'autocorrelation'], None),
+    (['tda'], [0.5]),  # This adds a coefficient in front of the auxiliary loss
+    (['lda', 'autocorrelation'], [2.0, 0.2]),
+])
+def test_multitask_training(main_cv_name, weights, auxiliary_loss_names, loss_coefficients):
+    """Run a full training of a MultiTaskCV.
+
+    Test:
+    * The CV is compatible with the PyTorch Lightning's Trainer.
+    * Export works correctly.
+    """
+    # Create the MultiTaskCV and the list of datasets.
+    multi_cv, datasets = create_multitask_cv_and_datasets(
+        main_cv_name, weights, auxiliary_loss_names, loss_coefficients)
+
+    # Train.
+    datamodule = DictionaryDataModule(datasets, shuffle=False, random_split=False)
+    trainer = pl.Trainer(max_epochs=1, log_every_n_steps=2, logger=None, enable_checkpointing=False)
+    trainer.fit(multi_cv, datamodule)
+
+    # Eval.
+    multi_cv.eval()
+    x = datasets[0]['data']
+    x_hat = multi_cv(x)
+    assert x_hat.shape == (x.shape[0], N_CVS)
+
+    # Do round-trip through torchscript.
+    with tempfile.NamedTemporaryFile('r', suffix='.ptc') as f:
+        multi_cv.to_torchscript(file_path=f.name, method='trace')
+        multi_cv_loaded = torch.jit.load(f.name)
+    x_hat2 = multi_cv_loaded(x)
+    assert torch.allclose(x_hat, x_hat2)

--- a/mlcvs/tests/test_cvs_multitask_multitask.py
+++ b/mlcvs/tests/test_cvs_multitask_multitask.py
@@ -283,7 +283,7 @@ def test_multitask_training(main_cv_name, weights, auxiliary_loss_names, loss_co
     assert x_hat.shape == (x.shape[0], N_CVS)
 
     # Do round-trip through torchscript.
-    with tempfile.NamedTemporaryFile('r', suffix='.ptc') as f:
+    with tempfile.NamedTemporaryFile('wb', suffix='.ptc') as f:
         multi_cv.to_torchscript(file_path=f.name, method='trace')
         multi_cv_loaded = torch.jit.load(f.name)
     x_hat2 = multi_cv_loaded(x)

--- a/mlcvs/tests/test_cvs_unsupervised_vae.py
+++ b/mlcvs/tests/test_cvs_unsupervised_vae.py
@@ -63,7 +63,7 @@ def test_vae_cv_training(weights):
     assert x_hat.shape == (batch_size, n_cvs)
 
     # Test export to torchscript.
-    with tempfile.NamedTemporaryFile('r', suffix='.ptc') as f:
+    with tempfile.NamedTemporaryFile('wb', suffix='.ptc') as f:
         model.to_torchscript(file_path=f.name, method='trace')
         model_loaded = torch.jit.load(f.name)
     x_hat2 = model_loaded(x)

--- a/mlcvs/tests/test_cvs_unsupervised_vae.py
+++ b/mlcvs/tests/test_cvs_unsupervised_vae.py
@@ -14,6 +14,8 @@ Test objects and function in mlcvs.cvs.unsupervised.vae.
 # GLOBAL IMPORTS
 # =============================================================================
 
+import tempfile
+
 import pytest
 import pytorch_lightning as pl
 import torch
@@ -59,3 +61,10 @@ def test_vae_cv_training(weights):
     model.eval()
     x_hat = model(x)
     assert x_hat.shape == (batch_size, n_cvs)
+
+    # Test export to torchscript.
+    with tempfile.NamedTemporaryFile('r', suffix='.ptc') as f:
+        model.to_torchscript(file_path=f.name, method='trace')
+        model_loaded = torch.jit.load(f.name)
+    x_hat2 = model_loaded(x)
+    assert torch.allclose(x_hat, x_hat2)


### PR DESCRIPTION
## Description
1. Implement ``MultiTaskCV``. Because the class dynamically inherits from the main CV, this doesn't work if the main CV uses ``__slots__`` but I thought this a rare case that we could avoid supporting.
2. Fix ``FastDictionaryLoader.get_stats()``.
   - By default, when there are multiple datasets, it computes the stats for all of them unless the ``dataset_idx`` argument is given.
   - I've also removed the batch iteration to simplify a bit the code for the multidataset case and because ``DictionaryDataset``s already have everything in memory anyway so this should be slightly faster than doing a for loop.
3. Extended ``AutocorrelationLoss`` and ``FisherDiscriminantLoss`` to multivariate features. I've also added a Lorentzian regularization to ``FisherDiscriminantLoss`` to avoid it to explode.
4. I've fixed a weird bug in the ``VariationalAutoencoderCV`` that resulted in wrong torchscript models.
   - Torchscript complained that I was splitting the output of the encoder into two (for the mean and variance) so I added two separate linear layers ``mean_nn`` and ``logvar_nn``.
   - I also modified ``FeedForward`` to support a ``last_layer_activation`` argument so that we can configure easily the encoder to have an activation layer also to the output layer (which is then fed to ``mean/logvar_nn``).
5. Various fixes to PEP8 style, documentation, and tests.

## Status
- [ ] Ready to go