### PR TITLE
Support for task-specific layers

### DIFF
--- a/mlcolvar/cvs/multitask/__init__.py
+++ b/mlcolvar/cvs/multitask/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ['MultiTaskCV']
 
-from mlcolvar.cvs.multitask.multitask import *
+from mlcolvar.cvs.multitask.multitask import MultiTaskCV

--- a/mlcolvar/cvs/multitask/multitask.py
+++ b/mlcolvar/cvs/multitask/multitask.py
@@ -109,7 +109,7 @@ class MultiTaskCV:
         # Copy all members of main_cv into this object.
         self.__dict__ = main_cv.__dict__
 
-        self.auxiliary_loss_fns = auxiliary_loss_fns
+        self.auxiliary_loss_fns = torch.nn.ModuleList(auxiliary_loss_fns)
         self.loss_coefficients = loss_coefficients
 
     def training_step(self, train_batch, batch_idx):


### PR DESCRIPTION
Task-specific layers can be added within the auxiliary loss functions of ``MultiTaskCV``, and now they will be trained.
